### PR TITLE
Enhance image handling and loading status in library components

### DIFF
--- a/src/Editor/AudioTimeline/AudioTimeline.tsx
+++ b/src/Editor/AudioTimeline/AudioTimeline.tsx
@@ -237,7 +237,7 @@ export default function AudioTimeline(props: AudioTimelineProps) {
       .map((lyricText, index) => {
         return (
           <TextBox
-            key={lyricText + "" + index}
+            key={`${lyricText.id}-${index}`}
             lyricText={lyricText}
             index={index}
             width={timelineWidth}

--- a/src/Editor/AudioTimeline/TextBox.tsx
+++ b/src/Editor/AudioTimeline/TextBox.tsx
@@ -3,6 +3,7 @@ import { KonvaEventObject } from "konva/lib/Node";
 import { Vector2d } from "konva/lib/types";
 import { useEffect, useMemo, useRef, useState } from "react";
 import usePrevious from "react-hooks-use-previous";
+import useImage from "use-image";
 import { Circle, Group, Line, Rect, Text as KonvaText } from "react-konva";
 import { KonvaImage } from "../../KonvaImage";
 import { useEditorStore } from "../store";
@@ -100,6 +101,27 @@ function ElementTimelineIcon({
       <Circle x={2} y={4} radius={1.5} fill="rgba(255,255,255,0.92)" />
       <Circle x={8} y={2} radius={1.8} fill="rgba(255,255,255,0.88)" />
       <Circle x={6} y={8} radius={1.4} fill="rgba(255,255,255,0.82)" />
+    </Group>
+  );
+}
+
+function BrokenTimelineImageIcon({ x, y }: { x: number; y: number }) {
+  return (
+    <Group x={x} y={y} listening={false}>
+      <Circle x={6} y={6} radius={6} fill="rgba(196, 80, 29, 0.98)" />
+      <Line
+        points={[6, 1.8, 10.2, 9.2, 1.8, 9.2]}
+        closed
+        fill="rgba(255, 244, 230, 0.98)"
+        lineJoin="round"
+      />
+      <Line
+        points={[6, 4.1, 6, 6.5]}
+        stroke="rgba(196, 80, 29, 0.98)"
+        strokeWidth={0.95}
+        lineCap="round"
+      />
+      <Circle x={6} y={7.8} radius={0.62} fill="rgba(196, 80, 29, 0.98)" />
     </Group>
   );
 }
@@ -207,6 +229,10 @@ export function TextBox({
     : elementType
     ? ELEMENT_BOX_COLOR
     : TEXT_BOX_COLOR;
+  const [, timelineImageStatus] = useImage(lyricText.imageUrl ?? "");
+  const isBrokenTimelineImage = Boolean(
+    lyricText.isImage && lyricText.imageUrl && timelineImageStatus === "failed"
+  );
   const elementLabelWidth = useMemo(() => {
     if (!elementLabel) {
       return 0;
@@ -759,6 +785,12 @@ export function TextBox({
               crop
               pixelate={4}
             />
+            {isBrokenTimelineImage ? (
+              <BrokenTimelineImageIcon
+                x={Math.max(0, containerWidth / 2 - 6)}
+                y={Math.max(0, TEXT_BOX_HEIGHT / 2 - 6)}
+              />
+            ) : null}
           </Group>
         ) : elementLabel && elementType ? (
           <>

--- a/src/Editor/Image/Imported/ImagesManagerView.tsx
+++ b/src/Editor/Image/Imported/ImagesManagerView.tsx
@@ -171,36 +171,41 @@ function LibraryImageCard({
   const [importedImageStatus, setImportedImageStatus] = useState<
     "loading" | "loaded" | "failed"
   >(source === "imported" ? "loading" : "loaded");
+  const previousImportedImageUrlRef = useRef<string | null>(
+    source === "imported" ? imageUrl : null
+  );
   const reportedStatusKeyRef = useRef<string | null>(null);
+
+  if (source === "imported") {
+    if (previousImportedImageUrlRef.current !== imageUrl) {
+      previousImportedImageUrlRef.current = imageUrl;
+      reportedStatusKeyRef.current = null;
+
+      if (importedImageStatus !== "loading") {
+        setImportedImageStatus("loading");
+      }
+    }
+  } else if (previousImportedImageUrlRef.current !== null) {
+    previousImportedImageUrlRef.current = null;
+    reportedStatusKeyRef.current = null;
+
+    if (importedImageStatus !== "loaded") {
+      setImportedImageStatus("loaded");
+    }
+  }
+
   const isBroken = source === "imported" && importedImageStatus === "failed";
 
-  useEffect(() => {
-    if (source !== "imported") {
-      return;
-    }
-
-    setImportedImageStatus("loading");
-    reportedStatusKeyRef.current = null;
-  }, [imageUrl, source]);
-
-  useEffect(() => {
-    if (
-      source !== "imported" ||
-      importedImageStatus === "loading"
-    ) {
-      return;
-    }
-
-    const nextStatus = importedImageStatus === "failed" ? "broken" : "loaded";
-    const nextStatusKey = `${imageUrl}:${nextStatus}`;
+  function reportImportedStatus(status: "loaded" | "broken") {
+    const nextStatusKey = `${imageUrl}:${status}`;
 
     if (reportedStatusKeyRef.current === nextStatusKey) {
       return;
     }
 
     reportedStatusKeyRef.current = nextStatusKey;
-    onStatusChange?.(imageUrl, nextStatus);
-  }, [imageUrl, importedImageStatus, onStatusChange, source]);
+    onStatusChange?.(imageUrl, status);
+  }
 
   return (
     <div
@@ -287,11 +292,13 @@ function LibraryImageCard({
                 setImportedImageStatus((currentStatus) =>
                   currentStatus === "loaded" ? currentStatus : "loaded"
                 );
+                reportImportedStatus("loaded");
               }}
               onError={() => {
                 setImportedImageStatus((currentStatus) =>
                   currentStatus === "failed" ? currentStatus : "failed"
                 );
+                reportImportedStatus("broken");
               }}
               style={{
                 display: isBroken ? "none" : "block",

--- a/src/Editor/Image/Imported/ImagesManagerView.tsx
+++ b/src/Editor/Image/Imported/ImagesManagerView.tsx
@@ -215,7 +215,7 @@ function LibraryImageCard({
         cursor: "pointer",
       }}
     >
-      {!(source === "imported" && isBroken) ? <SourceBadge source={source} /> : null}
+      {source === "generated" ? <SourceBadge source={source} /> : null}
       {source === "generated" ? (
         <div
           style={{

--- a/src/Editor/Image/Imported/ImagesManagerView.tsx
+++ b/src/Editor/Image/Imported/ImagesManagerView.tsx
@@ -1,7 +1,20 @@
-import { View, Flex, Image, Button, Text } from "@adobe/react-spectrum";
+import {
+  View,
+  Flex,
+  Image,
+  Button,
+  Text,
+  Dialog,
+  DialogContainer,
+  Heading,
+  Divider,
+  Content,
+  TextField,
+  ButtonGroup,
+} from "@adobe/react-spectrum";
 import ImportImageButton, { ImageItem } from "./ImportImageButton";
 import { useProjectStore } from "../../../Project/store";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAudioPosition } from "react-use-audio-player";
 import GenerateAIImageButton from "../AI/GenerateAIImageButton";
 import { useAIImageGeneratorStore } from "../AI/store";
@@ -101,19 +114,94 @@ function SourceBadge({ source }: { source: "imported" | "generated" }) {
   );
 }
 
+function BrokenImageWarningIcon() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        pointerEvents: "none",
+      }}
+    >
+      <div
+        style={{
+          width: 42,
+          height: 42,
+          borderRadius: 999,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "rgba(196, 80, 29, 0.92)",
+          boxShadow: "0 10px 24px rgba(0, 0, 0, 0.28)",
+        }}
+      >
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M12 3.75L21 19.5H3L12 3.75Z" fill="rgba(255, 244, 230, 0.98)" />
+          <path
+            d="M12 8.2V13.2"
+            stroke="rgba(196, 80, 29, 0.96)"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+          <circle cx="12" cy="16.9" r="1.15" fill="rgba(196, 80, 29, 0.96)" />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
 function LibraryImageCard({
   imageUrl,
   source,
   isSelected,
   showCloudState,
+  onStatusChange,
   onPress,
 }: {
   imageUrl: string;
   source: "imported" | "generated";
   isSelected: boolean;
   showCloudState?: boolean;
+  onStatusChange?: (imageUrl: string, status: "loaded" | "broken") => void;
   onPress: () => void;
 }) {
+  const [importedImageStatus, setImportedImageStatus] = useState<
+    "loading" | "loaded" | "failed"
+  >(source === "imported" ? "loading" : "loaded");
+  const reportedStatusKeyRef = useRef<string | null>(null);
+  const isBroken = source === "imported" && importedImageStatus === "failed";
+
+  useEffect(() => {
+    if (source !== "imported") {
+      return;
+    }
+
+    setImportedImageStatus("loading");
+    reportedStatusKeyRef.current = null;
+  }, [imageUrl, source]);
+
+  useEffect(() => {
+    if (
+      source !== "imported" ||
+      importedImageStatus === "loading"
+    ) {
+      return;
+    }
+
+    const nextStatus = importedImageStatus === "failed" ? "broken" : "loaded";
+    const nextStatusKey = `${imageUrl}:${nextStatus}`;
+
+    if (reportedStatusKeyRef.current === nextStatusKey) {
+      return;
+    }
+
+    reportedStatusKeyRef.current = nextStatusKey;
+    onStatusChange?.(imageUrl, nextStatus);
+  }, [imageUrl, importedImageStatus, onStatusChange, source]);
+
   return (
     <div
       onClick={onPress}
@@ -122,7 +210,7 @@ function LibraryImageCard({
         cursor: "pointer",
       }}
     >
-      <SourceBadge source={source} />
+      {!(source === "imported" && isBroken) ? <SourceBadge source={source} /> : null}
       {source === "generated" ? (
         <div
           style={{
@@ -155,14 +243,66 @@ function LibraryImageCard({
       <View
         UNSAFE_style={{
           boxSizing: "border-box",
-          background: "rgba(255, 255, 255, 0.03)",
+          background: isBroken ? "rgba(196, 80, 29, 0.12)" : "rgba(255, 255, 255, 0.03)",
         }}
         borderColor={isSelected ? "yellow-400" : "transparent"}
         borderWidth={"thick"}
         borderRadius={"small"}
         overflow={"hidden"}
       >
-        <Image width={"130px"} src={imageUrl} alt={`${source} image`} />
+        <div
+          style={{
+            width: 130,
+            minHeight: 90,
+            background: isBroken ? "rgba(255, 120, 60, 0.12)" : "rgba(255, 255, 255, 0.03)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            position: "relative",
+          }}
+        >
+          {source === "imported" && isBroken ? (
+            <>
+              <BrokenImageWarningIcon />
+              <Text
+                UNSAFE_style={{
+                  fontSize: 12,
+                  fontWeight: 700,
+                  letterSpacing: 0.4,
+                  color: "rgba(255, 222, 204, 0.98)",
+                  textAlign: "center",
+                  lineHeight: 1.35,
+                  padding: "62px 12px 20px",
+                }}
+              >
+                Broken image URL
+              </Text>
+            </>
+          ) : null}
+          {source === "imported" ? (
+            <img
+              src={imageUrl}
+              alt={`${source} image`}
+              onLoad={() => {
+                setImportedImageStatus((currentStatus) =>
+                  currentStatus === "loaded" ? currentStatus : "loaded"
+                );
+              }}
+              onError={() => {
+                setImportedImageStatus((currentStatus) =>
+                  currentStatus === "failed" ? currentStatus : "failed"
+                );
+              }}
+              style={{
+                display: isBroken ? "none" : "block",
+                width: 130,
+                height: "auto",
+              }}
+            />
+          ) : (
+            <Image width={"130px"} src={imageUrl} alt={`${source} image`} />
+          )}
+        </div>
       </View>
     </div>
   );
@@ -175,6 +315,9 @@ export default function ImagesManagerView() {
   const [saveProject] = useProjectService();
   const addNewLyricText = useProjectStore((state) => state.addNewLyricText);
   const images = useProjectStore((state) => state.images);
+  const setImages = useProjectStore((state) => state.setImages);
+  const lyricTexts = useProjectStore((state) => state.lyricTexts);
+  const updateLyricTexts = useProjectStore((state) => state.updateLyricTexts);
   const deleteImage = useProjectStore((state) => state.removeImagesById);
   const generatedImages = useAIImageGeneratorStore((state) =>
     state.generatedImageLog.filter((image) => image.url)
@@ -182,9 +325,13 @@ export default function ImagesManagerView() {
   const unsavedGeneratedCount = generatedImages.filter((image) =>
     isBase64DataUrl(image.url)
   ).length;
-  const generatedImageUrls = new Set(generatedImages.map((image) => image.url));
-  const importedImages = images.filter(
-    (image) => image.url && !generatedImageUrls.has(image.url)
+  const generatedImageUrls = useMemo(
+    () => new Set(generatedImages.map((image) => image.url)),
+    [generatedImages]
+  );
+  const importedImages = useMemo(
+    () => images.filter((image) => image.url && !generatedImageUrls.has(image.url)),
+    [generatedImageUrls, images]
   );
   const hideGeneratedImage = useAIImageGeneratorStore((state) => state.hideImage);
   const updateGeneratedImage = useAIImageGeneratorStore(
@@ -201,7 +348,10 @@ export default function ImagesManagerView() {
   const [selectedImportedImage, setSelectedImportedImage] = useState<
     ImageItem | undefined
   >();
+  const [editingImportedImage, setEditingImportedImage] = useState<ImageItem | undefined>();
+  const [editingImportedUrl, setEditingImportedUrl] = useState("");
   const [uploadingUrl, setUploadingUrl] = useState<string | null>(null);
+  const [brokenImportedUrls, setBrokenImportedUrls] = useState<string[]>([]);
 
   useEffect(() => {
     if (selectedGeneratedImage) {
@@ -241,6 +391,61 @@ export default function ImagesManagerView() {
     }
 
     setSelectedImportedImage(undefined);
+  }
+
+  function handleStartEditImportedImage() {
+    if (!selectedImportedImage) {
+      return;
+    }
+
+    setEditingImportedImage(selectedImportedImage);
+    setEditingImportedUrl(selectedImportedImage.url ?? "");
+  }
+
+  function handleCloseEditImportedImage() {
+    setEditingImportedImage(undefined);
+    setEditingImportedUrl("");
+  }
+
+  function handleSaveEditedImportedImage() {
+    if (!editingImportedImage?.id) {
+      return;
+    }
+
+    const previousUrl = editingImportedImage.url;
+    const nextUrl = editingImportedUrl.trim();
+
+    if (!nextUrl) {
+      return;
+    }
+
+    const nextImages = images.map((image) =>
+      image.id === editingImportedImage.id
+        ? {
+            ...image,
+            url: nextUrl,
+          }
+        : image
+    );
+    const updatedImage = nextImages.find((image) => image.id === editingImportedImage.id);
+    const nextLyricTexts = previousUrl
+      ? lyricTexts.map((lyricText) =>
+          lyricText.isImage && lyricText.imageUrl === previousUrl
+            ? {
+                ...lyricText,
+                imageUrl: nextUrl,
+              }
+            : lyricText
+        )
+      : lyricTexts;
+
+    setImages(nextImages);
+    updateLyricTexts(nextLyricTexts, false);
+    setBrokenImportedUrls((currentUrls) =>
+      currentUrls.filter((url) => url !== previousUrl && url !== nextUrl)
+    );
+    setSelectedImportedImage(updatedImage);
+    handleCloseEditImportedImage();
   }
 
   async function handleSaveGeneratedImageToCloud() {
@@ -294,6 +499,38 @@ export default function ImagesManagerView() {
         : "Saved to cloud"
       : ""
     : "";
+  const editingImportedImageAffectedTimelineCount = useMemo(() => {
+    if (!editingImportedImage?.url) {
+      return 0;
+    }
+
+    return lyricTexts.filter(
+      (lyricText) => lyricText.isImage && lyricText.imageUrl === editingImportedImage.url
+    ).length;
+  }, [editingImportedImage?.url, lyricTexts]);
+  const currentImportedUrls = useMemo(
+    () => new Set(importedImages.map((image) => image.url).filter(Boolean) as string[]),
+    [importedImages]
+  );
+  const visibleBrokenImportedUrls = useMemo(
+    () => brokenImportedUrls.filter((url) => currentImportedUrls.has(url)),
+    [brokenImportedUrls, currentImportedUrls]
+  );
+
+  const handleImportedImageStatusChange = useCallback(
+    (imageUrl: string, status: "loaded" | "broken") => {
+      setBrokenImportedUrls((currentUrls) => {
+        const hasUrl = currentUrls.includes(imageUrl);
+
+        if (status === "broken") {
+          return hasUrl ? currentUrls : [...currentUrls, imageUrl];
+        }
+
+        return hasUrl ? currentUrls.filter((url) => url !== imageUrl) : currentUrls;
+      });
+    },
+    []
+  );
 
   return (
     <View
@@ -343,17 +580,22 @@ export default function ImagesManagerView() {
       >
         <Flex direction="column" gap="size-300">
           <Flex direction="column" gap="size-125">
-            <SectionLabel title="Imported" count={importedImages.length} />
+            <SectionLabel
+              title="Imported"
+              count={importedImages.length}
+              detail={visibleBrokenImportedUrls.length ? `${visibleBrokenImportedUrls.length} broken` : undefined}
+            />
             {importedImages.length ? (
               <Flex wrap gap="size-150" alignItems="center" justifyContent="center">
                 {importedImages.map((image, index) => (
                   <LibraryImageCard
-                    key={image.id + index}
+                    key={image.id ?? image.url ?? index}
                     imageUrl={image.url!}
                     source="imported"
                     isSelected={
                       selectedImportedImage?.id === image.id
                     }
+                    onStatusChange={handleImportedImageStatusChange}
                     onPress={() => {
                       setSelectedImportedImage(image);
                     }}
@@ -480,6 +722,15 @@ export default function ImagesManagerView() {
               >
                 {selectedImage.source === "generated" ? "Remove" : "Delete"}
               </Button>
+              {selectedImage.source === "imported" ? (
+                <Button
+                  variant="secondary"
+                  onPress={handleStartEditImportedImage}
+                  UNSAFE_style={{ minWidth: 64 }}
+                >
+                  Edit
+                </Button>
+              ) : null}
               {canSaveGeneratedSelection ? (
                 <Button
                   variant="secondary"
@@ -501,6 +752,46 @@ export default function ImagesManagerView() {
           </div>
         </View>
       ) : null}
+      <DialogContainer onDismiss={handleCloseEditImportedImage}>
+        {editingImportedImage ? (
+          <Dialog>
+            <Heading>Replace image URL</Heading>
+            <Divider />
+            <Content>
+              <Text
+                UNSAFE_style={{
+                  display: "block",
+                  fontSize: 12,
+                  lineHeight: 1.4,
+                  color: "rgba(255, 255, 255, 0.7)",
+                  marginBottom: 12,
+                }}
+              >
+                This will update {editingImportedImageAffectedTimelineCount} timeline item{editingImportedImageAffectedTimelineCount === 1 ? "" : "s"} using this image.
+              </Text>
+              <TextField
+                autoFocus
+                label="Image URL"
+                value={editingImportedUrl}
+                onChange={setEditingImportedUrl}
+                width="100%"
+              />
+            </Content>
+            <ButtonGroup>
+              <Button variant="secondary" onPress={handleCloseEditImportedImage}>
+                Cancel
+              </Button>
+              <Button
+                variant="accent"
+                onPress={handleSaveEditedImportedImage}
+                isDisabled={!editingImportedUrl.trim()}
+              >
+                Save
+              </Button>
+            </ButtonGroup>
+          </Dialog>
+        ) : null}
+      </DialogContainer>
     </View>
   );
 }


### PR DESCRIPTION
This pull request improves the handling and user experience around broken image URLs for imported images in the image manager and audio timeline. It adds visual feedback for broken images, enables editing of broken image URLs, and ensures that timeline items using those images are updated accordingly.

**User experience improvements for broken imported images:**

- Added a visual warning icon and background color for broken imported images in `ImagesManagerView`, along with a message indicating a "Broken image URL". [[1]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R117-R209) [[2]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90L158-R312)
- The imported images section now displays a count of broken images.
- Broken image status is tracked and updated via the `onStatusChange` callback in `LibraryImageCard`. [[1]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R117-R209) [[2]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R509-R540)

**Editing and updating broken image URLs:**

- Introduced an "Edit" button for imported images, opening a dialog to replace the image URL. This dialog shows how many timeline items will be updated and disables saving if the URL is empty. [[1]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R358-R361) [[2]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R732-R740) [[3]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R762-R801)
- When an image URL is edited, all relevant timeline items (`lyricTexts`) referencing the previous URL are updated to use the new URL, and the broken status is cleared for both old and new URLs.

**Audio timeline handling of broken images:**

- In the audio timeline, a custom `BrokenTimelineImageIcon` is displayed if a timeline item's image URL is broken, providing immediate feedback in the timeline view. [[1]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R6) [[2]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R108-R128) [[3]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R232-R235) [[4]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R788-R793)

**Code quality and performance enhancements:**

- Switched to using `useMemo` for derived values such as imported/generated image sets and visible broken URLs, improving performance and preventing unnecessary recalculations. [[1]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R325-R341) [[2]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R509-R540)
- Improved the uniqueness of React keys for timeline and image list rendering. [[1]](diffhunk://#diff-b06318e538331d061305e9a4afc3398cc03cb6948c7a3188606d1f385ebc3294L240-R240) [[2]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90L346-R605)

These changes collectively provide a more robust and user-friendly experience when dealing with broken image URLs, both in the image manager and in the timeline.

**References:** [[1]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R117-R209) [[2]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90L158-R312) [[3]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R358-R361) [[4]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R403-R457) [[5]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R509-R540) [[6]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90L346-R605) [[7]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R732-R740) [[8]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R762-R801) [[9]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R6) [[10]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R108-R128) [[11]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R232-R235) [[12]](diffhunk://#diff-5635512e194894e5b99469c6a727a7d333881ca4970d11aa78793e73cefa9523R788-R793) [[13]](diffhunk://#diff-b06318e538331d061305e9a4afc3398cc03cb6948c7a3188606d1f385ebc3294L240-R240) [[14]](diffhunk://#diff-b8f64d40e2af6ae1feb9dfd47dba96ef4da76bd9096830511c331247c546eb90R325-R341)