### PR TITLE
Enhance error handling and add demo projects functionality

### DIFF
--- a/api/lyrictor-meta.js
+++ b/api/lyrictor-meta.js
@@ -1,8 +1,11 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 const DEFAULT_TITLE = "Lyrictor";
 const DEFAULT_DESCRIPTION =
   "Free browser-based lyric video editor with beat-synced visualizers, AI-generated backgrounds, and Apple Music-style scroll, plus desktop YouTube support. No download required for web editing.";
-const DEMO_PROJECTS_URL =
-  "https://firebasestorage.googleapis.com/v0/b/angelic-phoenix-314404.appspot.com/o/demo_projects.json?alt=media";
+const DEMO_PROJECTS_PATH = path.join(process.cwd(), "demo_projects.json");
+let cachedDemoProjects = null;
 
 function escapeHtml(value) {
   return String(value)
@@ -93,14 +96,13 @@ async function fetchPublishedFirestoreProject(publishedId) {
 }
 
 async function fetchDemoProject(publishedId) {
-  const response = await fetch(DEMO_PROJECTS_URL);
-
-  if (!response.ok) {
-    throw new Error(`Failed to load demo projects: ${response.status} ${response.statusText}`);
+  if (!cachedDemoProjects) {
+    const demoProjectsJson = await readFile(DEMO_PROJECTS_PATH, "utf8");
+    const projects = JSON.parse(demoProjectsJson);
+    cachedDemoProjects = Array.isArray(projects) ? projects : [];
   }
 
-  const projects = await response.json();
-  return projects.find((project) => project?.id === publishedId) || null;
+  return cachedDemoProjects.find((project) => project?.id === publishedId) || null;
 }
 
 async function fetchSharedProject(publishedId) {

--- a/api/sitemap.js
+++ b/api/sitemap.js
@@ -1,5 +1,8 @@
-const DEMO_PROJECTS_URL =
-  "https://firebasestorage.googleapis.com/v0/b/angelic-phoenix-314404.appspot.com/o/demo_projects.json?alt=media";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEMO_PROJECTS_PATH = path.join(process.cwd(), "demo_projects.json");
+let cachedDemoProjects = null;
 
 function buildOrigin(req) {
   const host = req.headers["x-forwarded-host"] || req.headers.host;
@@ -93,14 +96,13 @@ function buildUrlEntry(loc, options = {}) {
 }
 
 async function fetchDemoProjects() {
-  const response = await fetch(DEMO_PROJECTS_URL);
-
-  if (!response.ok) {
-    throw new Error(`Failed to load demo projects: ${response.status} ${response.statusText}`);
+  if (!cachedDemoProjects) {
+    const demoProjectsJson = await readFile(DEMO_PROJECTS_PATH, "utf8");
+    const projects = JSON.parse(demoProjectsJson);
+    cachedDemoProjects = Array.isArray(projects) ? projects : [];
   }
 
-  const projects = await response.json();
-  return Array.isArray(projects) ? projects : [];
+  return cachedDemoProjects;
 }
 
 async function fetchPublishedFirestoreProjects() {

--- a/demo_projects.json
+++ b/demo_projects.json
@@ -1,0 +1,4277 @@
+[
+  {
+    "id": "(Demo) Marcin, Delaney Bailey - Allergies",
+    "projectDetail": {
+      "name": "(Demo) Marcin, Delaney Bailey - Allergies",
+      "createdDate": "2024-10-20T03:54:35.045Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview211/v4/c0/4f/4a/c04f4a41-3d25-28ae-eba9-bd41a61c73b7/mzaf_9091601463058762426.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview211/v4/c0/4f/4a/c04f4a41-3d25-28ae-eba9-bd41a61c73b7/mzaf_9091601463058762426.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "editingMode": "static",
+      "resolution": "16/9",
+      "albumArtSrc": "https://cdn-p.smehost.net/sites/7c2f0176908e495c9abb97aeed6a7091/wp-content/uploads/2024/07/marcin-album-cover.jpg"
+    },
+    "lyricTexts": [
+      {
+        "id": 1729547988175,
+        "start": -0.0360015916666667,
+        "end": 3.8081241500000003,
+        "text": "Will you open up if I knock on your door?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729549372407,
+        "start": 8.028354941666667,
+        "end": 19.576821300000006,
+        "text": "Mm-mm, mm",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729549882739,
+        "start": 19.797861766666646,
+        "end": 30.95031061666664,
+        "text": "Hm-hm, hm-hm, hm",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729549887698,
+        "start": 31.244924758333365,
+        "end": 36.81712690000003,
+        "text": "Ah, ah-ah",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550126488,
+        "start": 41.776192611487254,
+        "end": 44.61227378648726,
+        "text": "Nothing left to give",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550161565,
+        "start": 45.624377244820614,
+        "end": 48.424456828153936,
+        "text": "Nothing left to say",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550190153,
+        "start": 48.969826769820614,
+        "end": 51.985915903153945,
+        "text": "I'll be on my way",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550215722,
+        "start": 57.227572512094866,
+        "end": 62.943781020428204,
+        "text": "Left all my love in April",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550252488,
+        "start": 64.63275622876154,
+        "end": 71.82502999542821,
+        "text": "Left you amongst the trees",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550285574,
+        "start": 72.4169751381655,
+        "end": 77.91717409649883,
+        "text": "Left you behind and spring will remind me",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729550308887,
+        "start": 78.23145869166666,
+        "end": 87.65583114166667,
+        "text": "There's nothing left of you, except allergies",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729552659049,
+        "start": -0.18000798185941042,
+        "end": 92.8400723446712,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 6,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 23.8
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 1.2,
+            "beatSyncIntensity": 0.9
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.457,
+              "color": {
+                "r": 201,
+                "g": 6,
+                "b": 1,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.685,
+              "color": {
+                "r": 151,
+                "g": 22,
+                "b": 2,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.344,
+              "color": {
+                "r": 248,
+                "g": 231,
+                "b": 28,
+                "a": 1
+              },
+              "beatSyncIntensity": 1
+            }
+          ]
+        }
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"p44v\",\"text\":\"Seeing ghosts in the hallway\\nLooks like your outline in my driveway\\nThere's a horizon disappearing on me\\nChase it on red eyes with your memory\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"21ng5\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5nr2s\",\"text\":\"Left all my love in April\\nLeft you amongst the trees\\nLeft you behind and spring will remind me\\nThere's nothing left of you, except allergies\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"d2tvh\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"9rfe\",\"text\":\"You and your gravitational pull\\nI'll be the ocean and you the moon\\nNot much to do when the sun goes down anymore\\nWill you open up if I knock on your door?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"ee02v\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"eitsb\",\"text\":\"Mm-mm, mm\\nHm-hm, hm-hm, hm\\nAh, ah-ah\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"655dv\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"butcl\",\"text\":\"Nothing left to give\\nNothing left to say\\nI'll be on my way\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6gqoo\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"btf0n\",\"text\":\"Left all my love in April\\nLeft you amongst the trees\\nLeft you behind and spring will remind me\\nThere's nothing left of you, except allergies\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": [],
+    "images": []
+  },
+  {
+    "id": "(Demo) Knocked Loose - Suffocate (feat. Poppy)",
+    "projectDetail": {
+      "name": "(Demo) Knocked Loose - Suffocate (feat. Poppy)",
+      "createdDate": "2024-05-26T17:45:45.864Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/b3/2e/dc/b32edc65-1152-6b38-4439-726da9d95c0b/mzaf_17022474792792973115.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/b3/2e/dc/b32edc65-1152-6b38-4439-726da9d95c0b/mzaf_17022474792792973115.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "albumArtSrc": "https://upload.wikimedia.org/wikipedia/en/1/1f/You_Won%27t_Go_Before_You%27re_Supposed_To.jpg",
+      "resolution": "16/9"
+    },
+    "lyricTexts": [
+      {
+        "id": 1716745933791.6,
+        "start": 0.003084217290232561,
+        "end": 24.21667184229024,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 57.2
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.2,
+            "beatSyncIntensity": 2.31
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.481,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.675
+            },
+            {
+              "stop": 0.501,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.635
+            },
+            {
+              "stop": 0.484,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 1.146
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716746490296.5,
+        "start": 25.734394046258515,
+        "end": 34.18433611626986,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 0
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.05,
+            "beatSyncIntensity": 4.63
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.154,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.733
+            },
+            {
+              "stop": 0.067,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.451
+            },
+            {
+              "stop": 0.094,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.721
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716746645117.7,
+        "start": 35.30462361581205,
+        "end": 58.11622257437641,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 88.3
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.05,
+            "beatSyncIntensity": 4.74
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.447,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.634
+            },
+            {
+              "stop": 0.603,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.511
+            },
+            {
+              "stop": 0.46,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 1.146
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716752268034,
+        "start": 1.1737852517006897,
+        "end": 3.4694273741496695,
+        "text": "STRANGLED",
+        "textY": 0.3274180724037601,
+        "textX": 0.4236313035494062,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716752926865.1,
+        "start": 1.7376144630586614,
+        "end": 3.466889420234284,
+        "text": "BY",
+        "textY": 0.4493701464655199,
+        "textX": 0.48384195970313276,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716752931026.6,
+        "start": 1.999430557187301,
+        "end": 3.4611227727333174,
+        "text": "EVERY",
+        "textY": 0.5265227290625945,
+        "textX": 0.46330671468540685,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716752935122.9,
+        "start": 2.5549337704722324,
+        "end": 3.457055226728173,
+        "text": "MISTAKE",
+        "textY": 0.6115598433930156,
+        "textX": 0.44269763581287175,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716753309312.1,
+        "start": 3.8308742645734806,
+        "end": 6.620961683790252,
+        "text": "THE",
+        "textY": 0.22976501305482805,
+        "textX": 0.28627319425506953,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716753374924.4,
+        "start": 4.300689754234726,
+        "end": 6.620029109754091,
+        "text": "WIND",
+        "textY": 0.16057441253263485,
+        "textX": 0.5932759598955548,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716753432887.8,
+        "start": 5.110104734791876,
+        "end": 6.608420870356591,
+        "text": "HUSH",
+        "textY": 0.40731070496083327,
+        "textX": 0.5594909665475588,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716753458251.3,
+        "start": 4.715033137138982,
+        "end": 6.612613989256986,
+        "text": "WILL",
+        "textY": 0.33550913838119883,
+        "textX": 0.38909708705331825,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716753570665.6,
+        "start": 5.877101668148322,
+        "end": 6.615158467153453,
+        "text": "CRIES",
+        "textY": 0.5443864229764991,
+        "textX": 0.3964416508246216,
+        "textBoxTimelineLevel": 7,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716753596309,
+        "start": 5.479761168607438,
+        "end": 6.611447142884346,
+        "text": "YOUR",
+        "textY": 0.6331592689295017,
+        "textX": 0.5433329262506912,
+        "textBoxTimelineLevel": 6,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754549569,
+        "start": 6.895440499267554,
+        "end": 10.019948820296378,
+        "text": "IN",
+        "textY": 0.3211488250652719,
+        "textX": 0.17022908666847456,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754549570,
+        "start": 7.158233525902292,
+        "end": 10.03494105110841,
+        "text": "THE",
+        "textY": 0.15274151436031108,
+        "textX": 0.28627319425506936,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754549571,
+        "start": 7.58545319010281,
+        "end": 10.039257616559102,
+        "text": "OF",
+        "textY": 0.404699738903392,
+        "textX": 0.7027099600879766,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754549572,
+        "start": 7.365554445780039,
+        "end": 10.027525930611306,
+        "text": "STORM",
+        "textY": 0.08746736292427974,
+        "textX": 0.6175130203408564,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754549573,
+        "start": 8.12025902113347,
+        "end": 10.061920018204157,
+        "text": "RESTLESS",
+        "textY": 0.7284595300261076,
+        "textX": 0.6983032218251944,
+        "textBoxTimelineLevel": 7,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754549574,
+        "start": 7.797592056293399,
+        "end": 10.058208693935049,
+        "text": "YOUR",
+        "textY": 0.6945169712793712,
+        "textX": 0.18859049609673323,
+        "textBoxTimelineLevel": 6,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716754619705,
+        "start": 8.946345077433456,
+        "end": 10.07923627449729,
+        "text": "FATE",
+        "textY": 0.46866840731070275,
+        "textX": 0.4706217449147867,
+        "textBoxTimelineLevel": 8,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 25,
+        "fontSize": 33
+      },
+      {
+        "id": 1716755185165.7,
+        "start": 11.832130002207373,
+        "end": 13.249669866419,
+        "text": "HAUNTING",
+        "textY": 0.5052219321148803,
+        "textX": 0.43389892605826935,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716755185166.7,
+        "start": 12.41341912580597,
+        "end": 13.251540721569658,
+        "text": "PRIDE",
+        "textY": 0.4386422976501283,
+        "textX": 0.4610738120120921,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "400",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 33
+      },
+      {
+        "id": 1716755185167.7,
+        "start": 13.605029422719747,
+        "end": 14.639689669631538,
+        "text": "DEFIED",
+        "textY": 0.43080939947780456,
+        "textX": 0.7012410473337163,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "500",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 72
+      },
+      {
+        "id": 1716755185168.7,
+        "start": 13.257732239611435,
+        "end": 14.638880611591759,
+        "text": "MORALS",
+        "textY": 0.4295039164490839,
+        "textX": 0.05271606632761884,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Darker Grotesque Variable",
+        "fontWeight": "600",
+        "isVisualizer": false,
+        "width": 0.31457519483233365,
+        "height": 44.93866666666645,
+        "shadowBlur": 15.6,
+        "fontSize": 72
+      },
+      {
+        "id": 1716756708290.5,
+        "start": 58.63059912208952,
+        "end": 67.66752799291355,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 0
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.05,
+            "beatSyncIntensity": 4.63
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.154,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.733
+            },
+            {
+              "stop": 0.067,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.451
+            },
+            {
+              "stop": 0.094,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.721
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716756762004.5,
+        "start": 69.31105726984089,
+        "end": 74.77382444642816,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 62.1
+          },
+          "fillRadialGradientEndRadius": {
+            "value": -0.3,
+            "beatSyncIntensity": 4.63
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.154,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.733
+            },
+            {
+              "stop": 0.067,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.451
+            },
+            {
+              "stop": 0.094,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.721
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716756906571,
+        "start": 74.75485024943323,
+        "end": 80.46954783871894,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 87.8
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.05,
+            "beatSyncIntensity": 4.63
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.154,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.733
+            },
+            {
+              "stop": 0.067,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.451
+            },
+            {
+              "stop": 0.094,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.721
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716757059111,
+        "start": 81.48962742857127,
+        "end": 104.12127609235105,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 88.3
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.05,
+            "beatSyncIntensity": 4.74
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.447,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.634
+            },
+            {
+              "stop": 0.603,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.511
+            },
+            {
+              "stop": 0.46,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 1.146
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716757597592,
+        "start": 68.18798226514645,
+        "end": 68.66131070493192,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 14.7
+          },
+          "fillRadialGradientEndRadius": {
+            "value": -0.3,
+            "beatSyncIntensity": 4.63
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.154,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.733
+            },
+            {
+              "stop": 0.067,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.451
+            },
+            {
+              "stop": 0.094,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.721
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716757710470.1,
+        "start": 68.70502254875285,
+        "end": 69.27583218831329,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 27.3
+          },
+          "fillRadialGradientEndRadius": {
+            "value": -0.3,
+            "beatSyncIntensity": 4.63
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.154,
+              "color": {
+                "r": 230,
+                "g": 224,
+                "b": 171,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.733
+            },
+            {
+              "stop": 0.067,
+              "color": {
+                "r": 37,
+                "g": 38,
+                "b": 37,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.451
+            },
+            {
+              "stop": 0.094,
+              "color": {
+                "r": 233,
+                "g": 222,
+                "b": 165,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.721
+            }
+          ]
+        }
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"ddosr\",\"text\":\"Suffocate\\nEclipsing weight\\nStrangled by every mistake\\nThe wind will hush your cries\\nIn the storm of your restless fate\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"c9jnl\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"d6sgi\",\"text\":\"Haunting pride (morals defied)\\nAre you conscious behind the knife?\\nOr is it just another disguise\\nDrink from me\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"f6b7m\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"emko0\",\"text\":\"Take it now, take it now\\nEverything that I have\\nLeaving nothing left\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"28hs4\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"671us\",\"text\":\"Eclipsing weight\\nStrangled by every mistake\\nBranded by all of your failures\\nA feeling that you can't shake\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5ampk\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"attr0\",\"text\":\"Eclipsing weight\\nShut your lying mouth\\nAre you conscious behind the knife?\\nIt all comes crashing down\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"aqckn\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"bqa66\",\"text\":\"Burdened by our connection\\nI long for separation\\nIn the waning glow\\nEvery breath tries hard to escape\\nYour reign is over now\\nHave you found your grave?\\nSuffocate\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6jnes\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"3tlq8\",\"text\":\"I will dig until I find the fucking root\\nI suffered because of you\\nI will dig until I find the fucking root\\nI suffered because of you\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": []
+  },
+  {
+    "id": "(Demo) Cafuné - Tek It",
+    "projectDetail": {
+      "name": "(Demo) Cafuné - Tek It",
+      "createdDate": "2024-11-10T05:03:57.856Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/b2/68/a1/b268a1fe-0e78-723a-59cc-5e86164889ce/mzaf_14068661107404438126.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/b2/68/a1/b268a1fe-0e78-723a-59cc-5e86164889ce/mzaf_14068661107404438126.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "editingMode": "static",
+      "resolution": "16/9",
+      "albumArtSrc": "https://t2.genius.com/unsafe/504x504/https%3A%2F%2Fimages.genius.com%2Fa71b4ddf4f80b8abfce1691be05b1f3b.1000x1000x1.png"
+    },
+    "lyricTexts": [
+      {
+        "id": 1731215263998.9,
+        "start": -0.017694766439908947,
+        "end": 4.61545433106576,
+        "text": "I watch the moon",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731217456691,
+        "start": -0.11738157584437287,
+        "end": 90.38039025182002,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 123.6
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.9,
+            "beatSyncIntensity": 1.46
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.65,
+              "color": {
+                "r": 240,
+                "g": 148,
+                "b": 162,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.226,
+              "color": {
+                "r": 235,
+                "g": 205,
+                "b": 211,
+                "a": 1
+              },
+              "beatSyncIntensity": 1.109
+            },
+            {
+              "stop": 0.424,
+              "color": {
+                "r": 209,
+                "g": 130,
+                "b": 141,
+                "a": 1
+              },
+              "beatSyncIntensity": 1
+            }
+          ]
+        }
+      },
+      {
+        "id": 1731215322975.9,
+        "start": 4.566717342716401,
+        "end": 7.757067558266222,
+        "text": "Let it run my mood",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215366455.3,
+        "start": 7.733931247165533,
+        "end": 12.690826303854877,
+        "text": "Can't stop thinking of you",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216937061.3,
+        "start": 13.129697233560094,
+        "end": 16.703624723182507,
+        "text": "I watch you (now I let it go)",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731217028347.9,
+        "start": 16.331185052154197,
+        "end": 19.66935031292517,
+        "text": "(And I watch as things play out like)",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215538422.9,
+        "start": 19.568439023316184,
+        "end": 25.714324752834457,
+        "text": "So long nice to know you I'll be moving on",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215714313.2,
+        "start": 25.975754967758757,
+        "end": 29.41770086167801,
+        "text": "We started off in such a nice place",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215744794.9,
+        "start": 29.41284426303858,
+        "end": 32.55667925456775,
+        "text": "We were talking the same language",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215797791.9,
+        "start": 32.57160386206898,
+        "end": 35.831623546485275,
+        "text": "I open and I'm closing",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215826295.3,
+        "start": 35.7274923537415,
+        "end": 38.13039151020409,
+        "text": "You can't stand the thought",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215956710,
+        "start": 38.16605141043083,
+        "end": 40.02937396825396,
+        "text": "Of a real beating heart",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731215991063.5,
+        "start": 39.94437427664402,
+        "end": 43.17462421768711,
+        "text": "You'd be holding, having trouble",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216017801.6,
+        "start": 43.21228799999999,
+        "end": 48.6008443356009,
+        "text": "Owning and admit that I am hoping",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216095131.9,
+        "start": 49.01966104454341,
+        "end": 53.617665306122376,
+        "text": "I watch the moon",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216164540.8,
+        "start": 53.61965196221805,
+        "end": 57.01407721912103,
+        "text": "Let it run my mood",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216499370.7,
+        "start": 57.00583313785273,
+        "end": 62.00614240362802,
+        "text": "Can't stop thinking of you",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216590574,
+        "start": 62.015130335965814,
+        "end": 65.69851831359273,
+        "text": "I watch you (now I let it go)",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216647521.3,
+        "start": 65.44883031565172,
+        "end": 68.63540092266788,
+        "text": "(And I watch as things play out like)",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216734609.5,
+        "start": 68.61736196210286,
+        "end": 75.00290003958996,
+        "text": "So long nice to know you I'll be moving on",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1731216773083.1,
+        "start": 75.16527417152632,
+        "end": 78.46095008731466,
+        "text": "Moving on",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"1e7pk\",\"text\":\"Where did you learn what it means to reciprocate?\\nAnd how much can I be expected to tolerate? Uh\\nSo I started to think 'bout the plans I made\\nThe debt unpaid\\nAnd you just can't call a spade a spade\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"3armo\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"880i8\",\"text\":\"I watch the moon\\nLet it run my mood\\nCan't stop thinking of you\\nI watch you (now I let it go)\\n(And I watch as things play out like)\\nSo long nice to know you I'll be moving on\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6op63\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"4oimh\",\"text\":\"We started off in such a nice place\\nWe were talking the same language\\nI open and I'm closing\\nYou can't stand the thought\\nOf a real beating heart\\nYou'd be holding, having trouble\\nOwning and admit that I am hoping\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6jv70\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6d635\",\"text\":\"I watch the moon\\nLet it run my mood\\nCan't stop thinking of you\\nI watch you (now I let it go)\\n(And I watch as things play out like)\\nSo long nice to know you I'll be moving on\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"chs4e\",\"text\":\"\\nMoving on\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5nl32\",\"text\":\"You, yeah I always know the truth\\nBut I can't just say it to you\\nYeah, I know the truth\\nI knew\\nYeah, I always know the truth\\nBut I can't just say it to you\\nYeah, I know the truth\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"s8rs\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"97bsd\",\"text\":\"I never thought we'd see it through\\nI never could rely on you\\nAnd few times your face came into view\\nInto view\\nI'm not into you\\nInto you\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": [],
+    "images": []
+  },
+  {
+    "id": "(Demo) Katy Kirby - Cool Dry Place",
+    "projectDetail": {
+      "name": "(Demo) Katy Kirby - Cool Dry Place",
+      "createdDate": "2024-10-22T13:23:36.184Z",
+      "audioFileName": " https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/79/05/f5/7905f50f-1524-5ed6-1a0d-03a852aca061/mzaf_9977719741784138667.plus.aac.ep.m4a",
+      "audioFileUrl": " https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/79/05/f5/7905f50f-1524-5ed6-1a0d-03a852aca061/mzaf_9977719741784138667.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "editingMode": "static",
+      "resolution": "16/9",
+      "albumArtSrc": "https://upload.wikimedia.org/wikipedia/en/5/5a/Cool_Dry_Place_%28album%29.jpg"
+    },
+    "lyricTexts": [
+      {
+        "id": 1729603803698.2,
+        "start": 0.03597177324263039,
+        "end": 3.482052353741497,
+        "text": "Would you keep me, keep me in a cool, dry place?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729603842338,
+        "start": 3.5475992380952586,
+        "end": 10.12322409070297,
+        "text": "With my head on your shoulders, not too much weight",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729603891282.8,
+        "start": 10.091515356009051,
+        "end": 20.300289306122437,
+        "text": "Would you keep me, keep me in a cool, dry place?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604026804.4,
+        "start": 24.676636444444444,
+        "end": 30.82060001814059,
+        "text": "And with all my extra rods and cones I see",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604064638.6,
+        "start": 31.619188680272114,
+        "end": 38.37467239909298,
+        "text": "That the rhythm's more important than the melody",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604107606.3,
+        "start": 38.417853823129256,
+        "end": 42.115736816326546,
+        "text": "Ten segments in an orange",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604216723,
+        "start": 45.299792689342375,
+        "end": 52.666796553287945,
+        "text": "Only so many ways that you can pull apart someone",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604486134.4,
+        "start": 53.60994278458053,
+        "end": 58.96252734693881,
+        "text": "Can I come over? Is it too late?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604534682.6,
+        "start": 59.20069137414968,
+        "end": 66.35186459863948,
+        "text": "Would you keep me, keep me in a cool, dry place?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604598231.2,
+        "start": 66.42911724263037,
+        "end": 73.14862918820859,
+        "text": "With my head on your shouldеrs, not too much weight",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604641726.9,
+        "start": 73.23453765079365,
+        "end": 80.9252874739229,
+        "text": "Would you keep me, keep me in a cool, dry placе?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604708971.1,
+        "start": 81.02756484353733,
+        "end": 87.31541551020399,
+        "text": "And once the dust has settled, then you'll know",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729604737248.9,
+        "start": 87.38723874829931,
+        "end": 90.04194031746032,
+        "text": "And once the dust has settled, then you'll know",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729605190769.4,
+        "start": -0.021790766439868752,
+        "end": 90.11626332879823,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 82.4
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 1.15,
+            "beatSyncIntensity": 0
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.243,
+              "color": {
+                "r": 255,
+                "g": 255,
+                "b": 255,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.643,
+              "color": {
+                "r": 65,
+                "g": 117,
+                "b": 5,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.663
+            },
+            {
+              "stop": 1,
+              "color": {
+                "r": 248,
+                "g": 231,
+                "b": 28,
+                "a": 0.47
+              },
+              "beatSyncIntensity": 1
+            },
+            {
+              "stop": 0.252,
+              "color": {
+                "r": 184,
+                "g": 233,
+                "b": 134,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            }
+          ]
+        }
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"fjdc8\",\"text\":\"Just another episode of tenderness\\nIn a long, long string of similar events\\nLike a chain or whip around my neck\\nThat's the only part I want, you say\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"h73i\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"2j2as\",\"text\":\"Can I come over? Is it too late?\\nWould you keep me, keep me in a cool, dry place?\\nWith my head on your shoulders, not too much weight\\nWould you keep me, keep me in a cool, dry place?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"3c8hg\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5aatv\",\"text\":\"And with all my extra rods and cones I see\\nThat the rhythm's more important than the melody\\nTen segments in an orange\\nOnly so many ways that you can pull apart someone\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"h33c\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"f8vqv\",\"text\":\"Can I come over? Is it too late?\\nWould you keep me, keep me in a cool, dry place?\\nWith my head on your shouldеrs, not too much weight\\nWould you keep me, keep me in a cool, dry placе?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"1jmkn\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"8lkf4\",\"text\":\"And once the dust has settled, then you'll know\\nThat you're gonna get more of me than you bargained for\\nAll the ways we can go wrong\\nWill we ever get that far?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5f23f\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6ghh3\",\"text\":\"Can I come over? Is it too late?\\nWould you keep me, keep me in a cool, dry place?\\nWith my head on your shoulders, not too much weight\\nWould you keep me, keep me in a cool, dry place?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6utf8\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"8qgfl\",\"text\":\"Can I come over? Is it too late?\\nWould you keep me, keep me in a cool, dry place?\\nWith my head on your shoulders, not too much weight\\nWould you keep me, keep me in a cool, dry place?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": [],
+    "images": []
+  },
+  {
+    "id": "(Demo) Polyphia - ABC",
+    "projectDetail": {
+      "name": "(Demo) Polyphia - ABC",
+      "createdDate": "2022-12-20T04:12:05.039Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/39/67/94/396794ac-91c8-5b3a-66bc-3439d69c8b7d/mzaf_10164867093096651411.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview122/v4/39/67/94/396794ac-91c8-5b3a-66bc-3439d69c8b7d/mzaf_10164867093096651411.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "resolution": "16/9",
+      "albumArtSrc": "https://upload.wikimedia.org/wikipedia/en/6/60/Album_cover_of_Polyphia_-_Remember_That_You_Will_Die.jpg"
+    },
+    "lyricTexts": [
+      {
+        "id": 1671509715067,
+        "start": 0.40701812557252437,
+        "end": 1.7705026805424156,
+        "text": "cause, like,",
+        "textY": 0.5065772223947275,
+        "textX": 0.36368966063183844,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671509732848,
+        "start": 0.1439637188208617,
+        "end": 1.7517575648360888,
+        "text": "word",
+        "textY": 0.48046559361121105,
+        "textX": 0.3098379860418743,
+        "textBoxTimelineLevel": 3
+      },
+      {
+        "id": 1671509746364,
+        "start": 1.0545780661050268,
+        "end": 1.7964444444444418,
+        "text": "that's a lot of letters",
+        "textY": 0.5490732566484579,
+        "textX": 0.4305969359446695,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671509958071,
+        "start": 1.835028182705552,
+        "end": 1.9365290829644228,
+        "text": "A",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671510220121,
+        "start": 1.9483541318227495,
+        "end": 2.0319499948956903,
+        "text": "B",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671510252146,
+        "start": 2.040631852060312,
+        "end": 2.1336323811299023,
+        "text": "C",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 3
+      },
+      {
+        "id": 1671510300703,
+        "start": 2.1399084346094104,
+        "end": 2.2296370606486975,
+        "text": "D",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 4
+      },
+      {
+        "id": 1671510322742,
+        "start": 2.2372508750540665,
+        "end": 2.3370336151789326,
+        "text": "E",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 5
+      },
+      {
+        "id": 1671510340278,
+        "start": 2.346605528198551,
+        "end": 2.4295519431825623,
+        "text": "F",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 6
+      },
+      {
+        "id": 1671510361151,
+        "start": 2.438684491499929,
+        "end": 2.523653238507695,
+        "text": "G",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671510466916,
+        "start": 2.5378220677447527,
+        "end": 2.6241883612730006,
+        "text": "H",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671510792606,
+        "start": 2.6319681407034703,
+        "end": 2.7389770184254125,
+        "text": "I",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671510810710,
+        "start": 2.742359363484105,
+        "end": 2.8448467671691966,
+        "text": "J",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671510829609,
+        "start": 2.8507893802345055,
+        "end": 2.9532767839195975,
+        "text": "K",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671510896931,
+        "start": 3.471491105527621,
+        "end": 3.563805192629799,
+        "text": "Q",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671510924053,
+        "start": 2.957044020100503,
+        "end": 3.050488475711892,
+        "text": "L",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671510939494,
+        "start": 3.054255711892797,
+        "end": 3.147700167504186,
+        "text": "M",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671510957193,
+        "start": 3.148636716917941,
+        "end": 3.2488633835846064,
+        "text": "N",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671510977908,
+        "start": 3.2464183584589614,
+        "end": 3.339862814070352,
+        "text": "O",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671510987082,
+        "start": 3.3436300502512566,
+        "end": 3.4664640871021777,
+        "text": "P",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671511115873,
+        "start": 3.8800922278056653,
+        "end": 3.991622579564459,
+        "text": "U",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671511135294,
+        "start": 3.5651822780569513,
+        "end": 3.660887470686768,
+        "text": "R",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671511150169,
+        "start": 3.6601332328308214,
+        "end": 3.7648813735343385,
+        "text": "S",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671511163768,
+        "start": 3.7641271356783923,
+        "end": 3.880178961474038,
+        "text": "T",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671511204998,
+        "start": 3.9980368174204672,
+        "end": 4.096002747068709,
+        "text": "V",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671511219714,
+        "start": 4.10204291457298,
+        "end": 4.211312529313348,
+        "text": "W",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671511234308,
+        "start": 4.207231591289783,
+        "end": 4.325544154103853,
+        "text": "X",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671511249272,
+        "start": 4.3212856281407115,
+        "end": 4.629500100502521,
+        "text": "Y",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671511260752,
+        "start": 4.643553835845896,
+        "end": 4.931421675041877,
+        "text": "Z",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671511367108,
+        "start": 5.00937635933806,
+        "end": 6.187595660322804,
+        "text": "Cut your pick out",
+        "textY": 0.49238578680203043,
+        "textX": 0.45819397993311034,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671511400448,
+        "start": 6.215524371991769,
+        "end": 8.421534657210401,
+        "text": "and put it my locket",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671511542588,
+        "start": 8.486351366906474,
+        "end": 11.49304009592326,
+        "text": "So I could kiss you whenever I wanted",
+        "textY": 0.661925601750547,
+        "textX": 0.25373878364905283,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671511654563,
+        "start": 12.004042839328426,
+        "end": 13.12703343884881,
+        "text": "Hyperventilating ",
+        "textY": 0.48468271334792123,
+        "textX": 0.34546360917248253,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671511668294,
+        "start": 13.19041813908873,
+        "end": 13.559282167865705,
+        "text": "when",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671511716111,
+        "start": 13.763944517985694,
+        "end": 14.763944517985694,
+        "text": "We be procreating",
+        "textY": 0.4649890590809628,
+        "textX": 0.3634097706879362,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671511733589,
+        "start": 15.160513237409965,
+        "end": 16.50359227817735,
+        "text": "Where'd you learn to do that thing?",
+        "textY": 0.4365426695842451,
+        "textX": 0.3673978065802592,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671511767262,
+        "start": 16.6668864268585,
+        "end": 19.33373270983212,
+        "text": "How you hold the bat when you swing",
+        "textY": 0.4912472647702407,
+        "textX": 0.32452642073778665,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671511842012,
+        "start": 19.19041743884892,
+        "end": 23.55323935731415,
+        "text": "I don't think I can breathe",
+        "textY": 0.6706783369803063,
+        "textX": 0.38035892323030907,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671511869007,
+        "start": 20.12579331414868,
+        "end": 23.55971254676259,
+        "text": "I don't think I can speak",
+        "textY": 0.6072210065645515,
+        "textX": 0.39232303090727816,
+        "textBoxTimelineLevel": 3
+      },
+      {
+        "id": 1671511885423,
+        "start": 21.569314561151078,
+        "end": 23.569879947155897,
+        "text": "I don't think I can think",
+        "textY": 0.550328227571116,
+        "textX": 0.405284147557328,
+        "textBoxTimelineLevel": 4
+      },
+      {
+        "id": 1671511887724,
+        "start": 22.961050292565947,
+        "end": 23.585605304556356,
+        "text": "I don't think I can see",
+        "textY": 0.486870897155361,
+        "textX": 0.42323030907278164,
+        "textBoxTimelineLevel": 5
+      },
+      {
+        "id": 1671512004207,
+        "start": 24.78600628193794,
+        "end": 25.42979781578541,
+        "text": "Shit",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671512087356,
+        "start": 26.649260901456586,
+        "end": 28.981573086546558,
+        "text": "Someone call a paramedic",
+        "textY": 0.40809628008752735,
+        "textX": 0.2966101694915254,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671512090577,
+        "start": 29.003937645244083,
+        "end": 32.17514389854314,
+        "text": "I can't speak, it's all phonetic",
+        "textY": 0.5218818380743983,
+        "textX": 0.34147557328015954,
+        "textBoxTimelineLevel": 3
+      },
+      {
+        "id": 1671512163096,
+        "start": 32.29745119177381,
+        "end": 35.77416403084836,
+        "text": "Made me forget every word 'cause, like, that's a lot of letters",
+        "textY": 0.46936542669584247,
+        "textX": 0.211864406779661,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671564202429,
+        "start": 36.075526041715314,
+        "end": 36.177026941974184,
+        "text": "A",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1
+      },
+      {
+        "id": 1671564202430,
+        "start": 36.18885199083251,
+        "end": 36.272447853905454,
+        "text": "B",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2
+      },
+      {
+        "id": 1671564202431,
+        "start": 36.28112971107008,
+        "end": 36.374130240139664,
+        "text": "C",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 3
+      },
+      {
+        "id": 1671564202432,
+        "start": 36.380406293619174,
+        "end": 36.47013491965846,
+        "text": "D",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 4
+      },
+      {
+        "id": 1671564202433,
+        "start": 36.47774873406383,
+        "end": 36.577531474188696,
+        "text": "E",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 5
+      },
+      {
+        "id": 1671564202434,
+        "start": 36.587103387208316,
+        "end": 36.670049802192324,
+        "text": "F",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 6
+      },
+      {
+        "id": 1671564202435,
+        "start": 36.67918235050969,
+        "end": 36.764151097517455,
+        "text": "G",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202436,
+        "start": 36.77831992675452,
+        "end": 36.86468622028276,
+        "text": "H",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202437,
+        "start": 36.872465999713235,
+        "end": 36.97947487743518,
+        "text": "I",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202438,
+        "start": 36.98285722249387,
+        "end": 37.08534462617896,
+        "text": "J",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202439,
+        "start": 37.09128723924427,
+        "end": 37.19377464292936,
+        "text": "K",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202440,
+        "start": 37.71198896453738,
+        "end": 37.804303051639565,
+        "text": "Q",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202441,
+        "start": 37.19754187911027,
+        "end": 37.29098633472166,
+        "text": "L",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202442,
+        "start": 37.294753570902564,
+        "end": 37.38819802651395,
+        "text": "M",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202443,
+        "start": 37.389134575927706,
+        "end": 37.48936124259437,
+        "text": "N",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202444,
+        "start": 37.486916217468725,
+        "end": 37.580360673080115,
+        "text": "O",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202445,
+        "start": 37.58412790926102,
+        "end": 37.70696194611194,
+        "text": "P",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202446,
+        "start": 38.120590086815426,
+        "end": 38.23212043857422,
+        "text": "U",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202447,
+        "start": 37.805680137066716,
+        "end": 37.90138532969653,
+        "text": "R",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202448,
+        "start": 37.90063109184059,
+        "end": 38.0053792325441,
+        "text": "S",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202449,
+        "start": 38.00462499468816,
+        "end": 38.1206768204838,
+        "text": "T",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202450,
+        "start": 38.238534676430234,
+        "end": 38.336500606078474,
+        "text": "V",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202451,
+        "start": 38.34254077358274,
+        "end": 38.45181038832311,
+        "text": "W",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202452,
+        "start": 38.44772945029955,
+        "end": 38.566042013113616,
+        "text": "X",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      },
+      {
+        "id": 1671564202453,
+        "start": 38.56178348715048,
+        "end": 38.86999795951228,
+        "text": "Y",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 7
+      },
+      {
+        "id": 1671564202454,
+        "start": 38.88405169485566,
+        "end": 39.17191953405164,
+        "text": "Z",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 8
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"7kb6s\",\"text\":\"[Pre-Chorus]\\nI don't think I can breathe\\nI don't think I can read\\nI don't think I can think\\nI don't think I can see\\nFuck\\n\\n[Chorus]\\nSomeone call a paramedic\\nI can't speak, it's all phonetic\\nMade me forget\\nEvery word 'cause, like, that's a lot of letters\\nABCDEFGHIJKLMNOPQRSTUVWXYZ\\n\\n[Verse 2]\\nCut your pic out and put it in my locket (Whoa, whoa, whoa)\\nSo I could kiss you whenever I wanted (Mmm, ah)\\nHyperventilating when (Oh-eh)\\nWe be procreating\\nWhere'd you learn to do that thing? (Ooh-whoa)\\nHow you hold the bat when you swing, yeah, yeah\\n\\n[Pre-Chorus]\\nI don't think I can breathe\\nI don't think I can read\\nI don't think I can think\\nI don't think I can see\\nHaha, shit[Chorus]\\nSomeone call a paramedic\\nI can't speak, it's all phonetic\\nMade me forget\\nEvery word 'cause, like, that's a lot of letters\\nABCDEFGHIJKLMNOPQRSTUVWXYZ\\n\\n[Verse 1]\\n911, hello? It's me, Sophia\\nYes, this is an emergency\\nYes, the way they put it down on me\\nGot the whole room tipsy\\nHyperventilating when\\nWe be procreating\\nWhere'd you learn to do that thing?\\nHow you hold the bat when you swing\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"43vjl\",\"text\":\"You might also like\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5gjh3\",\"text\":\"Memento Mori\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":12,\"key\":0}],\"data\":{}},{\"key\":\"419r\",\"text\":\"Polyphia\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":8,\"key\":0}],\"data\":{}},{\"key\":\"1urcl\",\"text\":\"Did you know that there’s a tunnel under Ocean Blvd\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":51,\"key\":1}],\"data\":{}},{\"key\":\"rsck\",\"text\":\"Lana Del Rey\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":12,\"key\":1}],\"data\":{}},{\"key\":\"e349v\",\"text\":\"Playing God\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":11,\"key\":2}],\"data\":{}},{\"key\":\"68run\",\"text\":\"Polyphia\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":8,\"key\":2}],\"data\":{}},{\"key\":\"fg1e1\",\"text\":\"[Chorus]\\nSomeone call a paramedic\\nI can't speak, it's all phonetic\\nMade me forget (Yeah)\\nEvery word 'cause, like, that's a lot of letters\\nABCDEFGHIJKLMNOPQRSTUVWXYZ\\n\\n[Bridge]\\nあいうえお\\nかきくけこ\\nさしすせそ\\nたちつてと\\nなにぬねの (Yah!)\\nはひふへほ\\nまみむめも\\nやいゆえよ\\nらりるれろ\\nぱぴぷぺぽ (Ah!)\\n\\n[Spoken]\\nえちょっと待って\\nちょっと待って\\nイケメンじゃない？\\nイケメンだよね？\\nむり、むり、むり、むり (Ooh-whoa, ooh-yeah)\\nヤバイ、超かっこいいんだけど。\\nむり、むり、絶対むり\\nヤバイんだけど  (Ooh-whoa)\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[{\"offset\":258,\"length\":47,\"style\":\"ITALIC\"},{\"offset\":327,\"length\":35,\"style\":\"ITALIC\"}],\"entityRanges\":[{\"offset\":175,\"length\":72,\"key\":3},{\"offset\":258,\"length\":115,\"key\":4}],\"data\":{}},{\"key\":\"b17da\",\"text\":\"[Guitar Solo]\\n(Ooh-ooh-ooh-ooh-ooh)\\nYeah, yeah, yeah, whoa-oh\\n(Ooh-ooh-ooh-ooh-ooh-ooh)\\n(Ooh-ooh-oh-oh-oh-oh)\\nHahaha\\nSomeone call a parame-me-me—\\n(Come on!)\\n(Ooh!)\\nABCDEFGHIJKLMNOPQRSTUVWXYZ\\n\\n[Outro]\\nあいうえお (Oh yeah)\\nかきくけこ\\nさしすせそ\\n(You got me, you got me forgetting all of my words)\\nたちつてと\\nなにぬねの (Yah!)\\nはひふへほ\\nまみむめも\\nやいゆえよ\\nらりるれろ\\nぱぴぷぺぽ (Ah!)\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{\"0\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/Polyphia-memento-mori-lyrics\",\"url\":\"https://genius.com/Polyphia-memento-mori-lyrics\"}},\"1\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/Lana-del-rey-did-you-know-that-theres-a-tunnel-under-ocean-blvd-lyrics\",\"url\":\"https://genius.com/Lana-del-rey-did-you-know-that-theres-a-tunnel-under-ocean-blvd-lyrics\"}},\"2\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/Polyphia-playing-god-lyrics\",\"url\":\"https://genius.com/Polyphia-playing-god-lyrics\"}},\"3\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/27347585/Polyphia-abc/Yah-ah\",\"url\":\"https://genius.com/27347585/Polyphia-abc/Yah-ah\"}},\"4\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/27347581/Polyphia-abc/Ooh-whoa-ooh-yeah-ooh-whoa\",\"url\":\"https://genius.com/27347581/Polyphia-abc/Ooh-whoa-ooh-yeah-ooh-whoa\"}}}}"
+  },
+  {
+    "id": "(Demo) (G)I-DLE - I DO",
+    "projectDetail": {
+      "name": "(Demo) (G)I-DLE - I DO",
+      "createdDate": "2024-03-03T16:00:45.659Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview116/v4/a4/6a/fc/a46afca3-803a-6c96-08bf-aeabe51cec96/mzaf_9148179664696836818.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview116/v4/a4/6a/fc/a46afca3-803a-6c96-08bf-aeabe51cec96/mzaf_9148179664696836818.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "resolution": "16/9",
+      "albumArtSrc": "https://is1-ssl.mzstatic.com/image/thumb/Video126/v4/5c/f0/81/5cf08102-c0c9-42f0-7247-abd91f7d8e30/Job7d822f90-7d15-46f6-9188-4b243f53b617-153070998-PreviewImage_Preview_Image_Intermediate_nonvideo_sdr_292081237_1507677819-Time1689814464828.png/592x592bb.webp"
+    },
+    "lyricTexts": [
+      {
+        "id": 1709483248953.3,
+        "start": 0.5152145425805178,
+        "end": 2.6725805440295067,
+        "text": "Stupid, foolish, afraid, I'm losing",
+        "textY": 0.5130548302872059,
+        "textX": 0.37381703470031535,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 292.2363281250001,
+        "height": 19.99999999999999,
+        "fontWeight": "300"
+      },
+      {
+        "id": 1709497371625.7,
+        "start": 2.6632858412698415,
+        "end": 4.82065184271883,
+        "text": "Everything I thought I couldn't",
+        "textY": 0.5130548302872059,
+        "textX": 0.37381703470031535,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 292.2363281250001,
+        "height": 19.99999999999999,
+        "fontWeight": "300"
+      },
+      {
+        "id": 1709497416327.1,
+        "start": 4.966668190476192,
+        "end": 7.12403419192518,
+        "text": "My whole world is falling apart",
+        "textY": 0.5130548302872059,
+        "textX": 0.37381703470031535,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 292.2363281250001,
+        "height": 19.99999999999999,
+        "fontWeight": "300"
+      },
+      {
+        "id": 1709497515731.2,
+        "start": 7.357232761904761,
+        "end": 11.134164477639464,
+        "text": "Don't you go falling in love",
+        "textY": 0.5104438642297646,
+        "textX": 0.39222646032623576,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 346.23632812500034,
+        "height": 19.99999999999998,
+        "fontWeight": "300",
+        "fontName": "Courier New"
+      },
+      {
+        "id": 1709497888453.8,
+        "start": 11.768844190476193,
+        "end": 15.545775906210896,
+        "text": "Trust me she's not the one",
+        "textY": 0.5104438642297646,
+        "textX": 0.39222646032623576,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 324.2363281250002,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "Courier New"
+      },
+      {
+        "id": 1709497952101.1,
+        "start": 16.303628190476196,
+        "end": 17.59722581097281,
+        "text": "She won't ever",
+        "textY": 0.5104438642297646,
+        "textX": 0.39222646032623576,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 185.23632812500037,
+        "height": 19.999999999999993,
+        "fontWeight": "300",
+        "fontName": "Courier New"
+      },
+      {
+        "id": 1709498186027.1,
+        "start": 17.79722768253968,
+        "end": 24.330567809758477,
+        "text": "Love you like I do",
+        "textY": 0.5013054830287202,
+        "textX": 0.40621762380193516,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "sans-serif"
+      },
+      {
+        "id": 1709498279166.1,
+        "start": 19.614740317460317,
+        "end": 24.325651095386032,
+        "text": "Hold you like I do",
+        "textY": 0.5417754569190597,
+        "textX": 0.44082734397866563,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "sans-serif"
+      },
+      {
+        "id": 1709498341356.4,
+        "start": 21.756166095238097,
+        "end": 24.330371141183566,
+        "text": "Know you like I do",
+        "textY": 0.5835509138381197,
+        "textX": 0.46365503175480705,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "sans-serif"
+      },
+      {
+        "id": 1709498682927.1,
+        "start": 24.545418158730158,
+        "end": 28.322349874464862,
+        "text": "Don't you go falling in love",
+        "textY": 0.5104438642297646,
+        "textX": 0.39222646032623576,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 346.23632812500034,
+        "height": 19.99999999999998,
+        "fontWeight": "300",
+        "fontName": "Courier New"
+      },
+      {
+        "id": 1709498682928.1,
+        "start": 28.95702958730159,
+        "end": 32.733961303036295,
+        "text": "'Cause I'ma break that shit up",
+        "textY": 0.5104438642297646,
+        "textX": 0.39222646032623576,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 371.23632812500045,
+        "height": 20,
+        "fontWeight": "300",
+        "fontName": "Courier New"
+      },
+      {
+        "id": 1709498682929.1,
+        "start": 33.49181358730159,
+        "end": 34.785411207798205,
+        "text": "I won't let her",
+        "textY": 0.5104438642297646,
+        "textX": 0.39222646032623576,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 185.23632812500037,
+        "height": 19.999999999999993,
+        "fontWeight": "300",
+        "fontName": "Courier New"
+      },
+      {
+        "id": 1709498757900.7,
+        "start": 35.052288,
+        "end": 41.5856281272188,
+        "text": "Love you like I do",
+        "textY": 0.5013054830287202,
+        "textX": 0.40621762380193516,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "sans-serif"
+      },
+      {
+        "id": 1709498757901.7,
+        "start": 36.86980063492064,
+        "end": 41.58071141284635,
+        "text": "Touch you like I do",
+        "textY": 0.5417754569190597,
+        "textX": 0.44082734397866563,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "sans-serif"
+      },
+      {
+        "id": 1709498757902.7,
+        "start": 39.01122641269841,
+        "end": 42.593161236421665,
+        "text": "Nothing like I do",
+        "textY": 0.5835509138381197,
+        "textX": 0.46365503175480705,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "300",
+        "fontName": "sans-serif"
+      },
+      {
+        "id": 1709498872656.4,
+        "start": 42.592263256235825,
+        "end": 44.28470474662574,
+        "text": "Nothing like I do",
+        "textY": 0.5835509138381197,
+        "textX": 0.46365503175480705,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 223.23632812500054,
+        "height": 19.999999999999996,
+        "fontWeight": "100",
+        "fontName": "sans-serif"
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"av9pf\",\"text\":\"Oh-oh-oh\\nHit me like a shot in the heart\\nNever shoulda played you so hard\\nGuess I played myself, that's my fault\\nOoh-ooh-ooh\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"4ign\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"bo619\",\"text\":\"I don't even know how to think\\n'Cause now she got your heart so I feel\\nStupid, foolish, afraid, I'm losing\\nEverything I thought I couldn't\\nMy whole world is falling apart\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"8oltb\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"7h0p6\",\"text\":\"Don't you go falling in love\\nTrust me she's not the one\\nShe won't ever\\nLove you like I do\\nHold you like I do\\nKnow you like I do\\nDon't you go fallin' in love\\n'Cause I'ma break that shit up\\nI won't let her\\nLove you like I do\\nTouch you like I do\\nNothing like I do\\nNothing like I do\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"aj7tv\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"8p83s\",\"text\":\"Hit me like a poisonous dart\\nYou were trouble right from the start\\nShould have ran, I guess it's my fault\\nMm-mm-mm\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"aqgng\",\"text\":\"I don't even know how to think\\n'Cause now she got your heart so I feel\\nStupid, foolish, afraid, I'm losing\\nEverything I thought I couldn't\\nMy whole world is falling apart\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"7qrb7\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"82mrt\",\"text\":\"Don't you go falling in love\\nTrust me she's not the one\\nShe won't ever\\nLove you like I do\\nHold you like I do\\nKnow you like I do\\nDon't you go fallin' in love\\n'Cause I'ma break that shit up\\nI won't let her\\nLove you like I do\\nTouch you like I do\\nNothing like I do\\nNothing like I do\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": []
+  },
+  {
+    "id": "(Demo) Invent Animate - Dark",
+    "projectDetail": {
+      "name": "(Demo) Invent Animate - Dark",
+      "createdDate": "2024-03-03T20:41:49.514Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/dc/1d/b7/dc1db7f8-570a-3a02-075c-a8da1c72ac2a/mzaf_17235884550229123499.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/dc/1d/b7/dc1db7f8-570a-3a02-075c-a8da1c72ac2a/mzaf_17235884550229123499.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "resolution": "16/9",
+      "albumArtSrc": "https://t2.genius.com/unsafe/495x495/https%3A%2F%2Fimages.genius.com%2Fb6968cca47c3913a2ef6ff90173e011f.1000x1000x1.png"
+    },
+    "images": [
+      {
+        "id": "1721512069441https://wallpapercave.com/wp/wp12700835.jpg",
+        "url": "https://wallpapercave.com/wp/wp12700835.jpg",
+        "imageHeight": 1440,
+        "imageWidth": 2560
+      }
+    ],
+    "lyricTexts": [
+      {
+        "id": 1709501218036.1,
+        "start": 8.300914911132708,
+        "end": 8.776582954586843,
+        "text": "PEER",
+        "textY": 0.46340562095653137,
+        "textX": 0.4441581840317025,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501373486.2,
+        "start": 8.823305143857116,
+        "end": 9.13724366943458,
+        "text": "IN",
+        "textY": 0.4640417063497449,
+        "textX": 0.4750744930492279,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501435223.9,
+        "start": 9.153546364834558,
+        "end": 9.467484890412024,
+        "text": "TO",
+        "textY": 0.46386999694754316,
+        "textX": 0.46557412250696273,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501451356.1,
+        "start": 9.497156374473805,
+        "end": 9.900024400651187,
+        "text": "MY",
+        "textY": 0.4640417063497449,
+        "textX": 0.46502259445588295,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501463080.6,
+        "start": 9.951085893964141,
+        "end": 10.662283405078355,
+        "text": "EYES",
+        "textY": 0.4414859015140995,
+        "textX": 0.41377890683862545,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 72,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.18129812981298113,
+        "height": 65.44800000000001,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501567773.8,
+        "start": 9.98910711276068,
+        "end": 10.077543299611856,
+        "text": "EYES",
+        "textY": 0.42941428424161315,
+        "textX": 0.4064392138557758,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 72,
+        "fontWeight": "800",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501595310.2,
+        "start": 10.164289442664113,
+        "end": 10.25272562951529,
+        "text": "EYES",
+        "textY": 0.4446609073507228,
+        "textX": 0.4167856890248028,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 72,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501612066.4,
+        "start": 10.494780109330783,
+        "end": 10.58321629618196,
+        "text": "EYES",
+        "textY": 0.44019735712007557,
+        "textX": 0.4178323710020845,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 72,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501715629.9,
+        "start": 12.495298783755578,
+        "end": 14.162239837192924,
+        "text": "ECLIPSED",
+        "textY": 0.4666924778504317,
+        "textX": 0.3883047587208004,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.22530253025302557,
+        "height": 42.72299999999995,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501715630.9,
+        "start": 14.555407831787116,
+        "end": 15.292688771551289,
+        "text": "LENSES",
+        "textY": 0.4633489322752054,
+        "textX": 0.4132577419100722,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501715631.9,
+        "start": 15.400978085932064,
+        "end": 15.974750965502464,
+        "text": "REFLECT",
+        "textY": 0.4642412660196756,
+        "textX": 0.3988543699606263,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.20990099009901028,
+        "height": 42.72299999999995,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709501715632.9,
+        "start": 16.245380425361343,
+        "end": 17.96409903119338,
+        "text": "THE DISTANCE",
+        "textY": 0.4635866368148408,
+        "textX": 0.3329796546968583,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 235.3079223632812,
+        "height": 93.99999999999986,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502132137.4,
+        "start": 18.25061395686702,
+        "end": 20.01841537803578,
+        "text": "BETWEEN",
+        "textY": 0.2564863667566897,
+        "textX": 0.3934032749062914,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.23410341034103446,
+        "height": 42.72299999999993,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502132138.4,
+        "start": 18.62892581433402,
+        "end": 20.331682919051904,
+        "text": "YOU",
+        "textY": 0.41501489355920207,
+        "textX": 0.44936683951071976,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502132139.4,
+        "start": 20.665769078462183,
+        "end": 22.574857782948406,
+        "text": "WE ARE FURTHER",
+        "textY": 0.3399833296363964,
+        "textX": 0.30153068780817227,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.4796479647964802,
+        "height": 85.4459999999995,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502194545.5,
+        "start": 19.170398394370398,
+        "end": 20.01565984642063,
+        "text": "AND",
+        "textY": 0.5460054564026176,
+        "textX": 0.4491503083645238,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502209351.7,
+        "start": 19.644325517566337,
+        "end": 20.342675966808176,
+        "text": "ME",
+        "textY": 0.6757288285435837,
+        "textX": 0.4640378808621204,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502401009.5,
+        "start": 23.60032898932214,
+        "end": 24.73275440788793,
+        "text": "HOLD MY ",
+        "textY": 0.46360052173925737,
+        "textX": 0.05162155314902437,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.2220022002200222,
+        "height": 42.72299999999998,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502462940,
+        "start": 24.750042087530908,
+        "end": 25.155150230055188,
+        "text": "BREATH",
+        "textY": 0.4608524070896536,
+        "textX": 0.7604855892391478,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502716751.8,
+        "start": 29.936666294345383,
+        "end": 31.18881481568232,
+        "text": "BUT",
+        "textY": 0.274772603260199,
+        "textX": 0.11577690647260502,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502732698.9,
+        "start": 30.52999834378341,
+        "end": 31.18423696724799,
+        "text": "WARMTH",
+        "textY": 0.533199385567431,
+        "textX": 0.7111301385645418,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.22200220022002196,
+        "height": 42.72299999999999,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502768053.7,
+        "start": 30.250800177329175,
+        "end": 31.18677769308126,
+        "text": "THE",
+        "textY": 0.10022888965551537,
+        "textX": 0.7093413523846296,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502895914.9,
+        "start": 30.994961986831143,
+        "end": 31.18067738182528,
+        "text": "IS",
+        "textY": 0.7330361157386395,
+        "textX": 0.21998282489967763,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709502909464.8,
+        "start": 31.259107940276547,
+        "end": 33.776095385460685,
+        "text": "GONE",
+        "textY": 0.4612305730062032,
+        "textX": 0.4293030446535645,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709503194272.9,
+        "start": 39.44166523602957,
+        "end": 41.09977875495296,
+        "text": "LEFT TO STUMBLE IN THE",
+        "textY": 0.4629278225332008,
+        "textX": 0.20761711111738393,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.6059405940594063,
+        "height": 42.72299999999991,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1709503194277,
+        "start": 41.14208279408122,
+        "end": 42.823480677473974,
+        "text": "DARK",
+        "textY": 0.4628346404913664,
+        "textX": 0.4305077672756324,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "900",
+        "fontName": "Helvetica",
+        "shadowBlur": 25
+      },
+      {
+        "id": 1711497973357.2,
+        "start": 12.992066132801266,
+        "end": 14.168483005657288,
+        "text": "ECLIPSED",
+        "textY": 0.4699683755233713,
+        "textX": 0.3894072945532152,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.2319031903190317,
+        "height": 42.72299999999989,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1711929743687.5,
+        "start": 25.396067266666666,
+        "end": 29.281112512013536,
+        "text": "MY FINGERTIPS",
+        "textY": 0.1277310770103345,
+        "textX": 0.3474742993292119,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 40,
+        "width": 0.4497249724972496,
+        "height": 72.72000000000001,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1721517234921.4,
+        "start": -0.14230599999946983,
+        "end": 89.88781650000053,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 6,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 0
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 3.2,
+            "beatSyncIntensity": 0.87
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0,
+              "color": {
+                "r": 255,
+                "g": 179,
+                "b": 186
+              },
+              "beatSyncIntensity": 0.698
+            },
+            {
+              "stop": 0.667,
+              "color": {
+                "r": 9,
+                "g": 9,
+                "b": 9,
+                "a": 1
+              },
+              "beatSyncIntensity": 1.367
+            },
+            {
+              "stop": 0.309,
+              "color": {
+                "r": 25,
+                "g": 25,
+                "b": 25,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.352
+            }
+          ]
+        }
+      },
+      {
+        "id": 1721517896106.2,
+        "start": -0.02358093333360181,
+        "end": 89.8986262666664,
+        "text": "",
+        "textY": 0.5702426278431708,
+        "textX": 0.4346626591432581,
+        "textBoxTimelineLevel": 7,
+        "isImage": true,
+        "imageUrl": "https://wallpapercave.com/wp/wp12700835.jpg",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1721519830773.7,
+        "start": 21.748747108291365,
+        "end": 22.569552922760668,
+        "text": "THAN WE SEEM",
+        "textY": 0.6171224249449073,
+        "textX": 0.32594244153486707,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 47,
+        "fontWeight": "300",
+        "fontName": "Helvetica",
+        "width": 0.4796479647964802,
+        "height": 85.4459999999995,
+        "shadowBlur": 25
+      },
+      {
+        "id": 1721520038774.5,
+        "start": 27.218556008460588,
+        "end": 29.273971294416594,
+        "text": "GRAZE YOUR PALMS",
+        "textY": 0.7816260852958531,
+        "textX": 0.29936878463248967,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontSize": 40,
+        "width": 0.4497249724972496,
+        "height": 72.72000000000001,
+        "shadowBlur": 25
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"em932\",\"text\":\"Peer into my eyes\\nEclipsed lenses reflect the distance\\nBetween you and me\\nWe are further than we seem\\nHold my breath, my fingertips graze your palms\\nBut the warmth is gone\\nLeft to stumble in the dark\\nI blinked and part of me was gone\\nHope goes up in smoke\\nVapor dissipates\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"56d11\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"cg7s1\",\"text\":\"I lost my shadow\\nI feel you slipping away, but I need you to stay\\nYou contour the source to black out the light\\nMy shadow\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"707pk\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"9sjec\",\"text\":\"For the sake of life, I cross the line\\nTo look back at the day\\nI left myself behind, self-separated from soul\\nI lost my shadow\\nBlack out\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"e1eru\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"an8a1\",\"text\":\"Dancing shapes against the wall\\nThe somber melody inside\\nSings in black and white\\nThe glow flickers out, glimmer into night\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"a66tq\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"b8jk3\",\"text\":\"I lost my shadow\\nBlack out the light\\nHollow, cold\\nSelf from soul\\nSelf-separated from soul\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"1h4vq\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"3fo96\",\"text\":\"I lost my shadow\\nBlack out the light\\nHollow and cold\\nSelf from soul\\nI lost my shadow\\nBlack out the light\\nHollow and cold\\nSelf from soul\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"as4k9\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"7fngt\",\"text\":\"For the sake of life, I cross the line\\nTo look back at the day\\nI left myself behind, self-separated from soul\\nI lost my shadow, shadow\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6fmf9\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"1l0d4\",\"text\":\"I lost my shadow\\nBlack out the light\\nHollow and cold\\nSelf from soul\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": []
+  },
+  {
+    "id": "(Demo) The Backseat Lovers - Kilby Girl",
+    "projectDetail": {
+      "name": "(Demo) The Backseat Lovers - Kilby Girl",
+      "createdDate": "2024-10-23T13:15:28.599Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/72/a7/fb/72a7fb62-e3d1-c21b-e032-11987d92c59a/mzaf_9669503607689821264.plus.aac.p.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/72/a7/fb/72a7fb62-e3d1-c21b-e032-11987d92c59a/mzaf_9669503607689821264.plus.aac.p.m4a",
+      "isLocalUrl": false,
+      "editingMode": "static",
+      "resolution": "16/9",
+      "albumArtSrc": "https://f4.bcbits.com/img/a4171388314_65"
+    },
+    "lyricTexts": [
+      {
+        "id": 1729690866441.1,
+        "start": -0.05985814058956916,
+        "end": 29.97134004535147,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 4,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 360.9
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 1.35,
+            "beatSyncIntensity": 0.26
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.236,
+              "color": {
+                "r": 94,
+                "g": 110,
+                "b": 78,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.548,
+              "color": {
+                "r": 151,
+                "g": 143,
+                "b": 131,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.813,
+              "color": {
+                "r": 212,
+                "g": 203,
+                "b": 164,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            }
+          ]
+        }
+      },
+      {
+        "id": 1729690395725.3,
+        "start": 0.3853734603174924,
+        "end": 1.8283237006803035,
+        "text": "Better than I do",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729690433535.3,
+        "start": 4.728793106575964,
+        "end": 5.980197297052154,
+        "text": "And I'm dying",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729690493485.7,
+        "start": 5.999269442176943,
+        "end": 8.42389318820869,
+        "text": "To figure out what she's hiding",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729690704720.9,
+        "start": 8.954806276643959,
+        "end": 11.666749097505638,
+        "text": "She's playing it cool but she's lying",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729690743320.7,
+        "start": 11.865079873015812,
+        "end": 13.571405931972729,
+        "text": "Better than I do",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729712271873.4,
+        "start": 13.37818790022676,
+        "end": 29.977219337868487,
+        "text": "♫",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"d50oi\",\"text\":\"[Verse 1]\\nWe're both throwing smoke into the night\\nIt's raining, I suppose that you need a ride\\nShe said, \\\"I've got nothin' to do and neither do you\\nThere's a place down the road where we can waste the whole afternoon\\\"\\n\\n[Chorus]\\nI overheard that she was nineteen\\nShe's got a fake ID and a nose ring\\nThose kind of girls tend to know things\\nBetter than I do\\nAnd I'm dying\\nTo figure out what she's hiding\\nShe's playing it cool but she's lying\\nBetter than I do\\n\\n[Verse 2]\\nFeels like a night to carry a tune\\nI've been carrying yours since you wrecked my room\\nAnd I've got nothin' to do and neither do you\\nSo we'll chase jack with love\\nAnd waste away the whole afternoon\\n\\n[Chorus]\\nI overheard that she was nineteen\\nShe's got a fake ID and a nose ring\\nThose kind of girls tend to know things\\nBetter than I do\\nAnd I'm dying\\nTo figure out what she's hiding\\nShe's playing it cool but she's lying\\nBetter than I do\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":10,\"length\":40,\"key\":0},{\"offset\":51,\"length\":44,\"key\":1},{\"offset\":96,\"length\":122,\"key\":2},{\"offset\":263,\"length\":75,\"key\":3},{\"offset\":356,\"length\":100,\"key\":4},{\"offset\":468,\"length\":85,\"key\":5},{\"offset\":554,\"length\":45,\"key\":6},{\"offset\":600,\"length\":29,\"key\":7},{\"offset\":675,\"length\":126,\"key\":8},{\"offset\":816,\"length\":86,\"key\":9}],\"data\":{}}],\"entityMap\":{\"0\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/27030720/The-backseat-lovers-kilby-girl/Were-both-throwing-smoke-into-the-night\",\"url\":\"https://genius.com/27030720/The-backseat-lovers-kilby-girl/Were-both-throwing-smoke-into-the-night\"}},\"1\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/31046268/The-backseat-lovers-kilby-girl/Its-raining-i-suppose-that-you-need-a-ride\",\"url\":\"https://genius.com/31046268/The-backseat-lovers-kilby-girl/Its-raining-i-suppose-that-you-need-a-ride\"}},\"2\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/28132057/The-backseat-lovers-kilby-girl/She-said-ive-got-nothin-to-do-and-neither-do-you-theres-a-place-down-the-road-where-we-can-waste-the-whole-afternoon\",\"url\":\"https://genius.com/28132057/The-backseat-lovers-kilby-girl/She-said-ive-got-nothin-to-do-and-neither-do-you-theres-a-place-down-the-road-where-we-can-waste-the-whole-afternoon\"}},\"3\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/27983816/The-backseat-lovers-kilby-girl/Shes-got-a-fake-id-and-a-nose-ring-those-kind-of-girls-tend-to-know-things\",\"url\":\"https://genius.com/27983816/The-backseat-lovers-kilby-girl/Shes-got-a-fake-id-and-a-nose-ring-those-kind-of-girls-tend-to-know-things\"}},\"4\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/28803641/The-backseat-lovers-kilby-girl/And-im-dying-to-figure-out-what-shes-hiding-shes-playing-it-cool-but-shes-lying-better-than-i-do\",\"url\":\"https://genius.com/28803641/The-backseat-lovers-kilby-girl/And-im-dying-to-figure-out-what-shes-hiding-shes-playing-it-cool-but-shes-lying-better-than-i-do\"}},\"5\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/18598077/The-backseat-lovers-kilby-girl/Feels-like-a-night-to-carry-a-tune-ive-been-carrying-yours-since-you-wrecked-my-room\",\"url\":\"https://genius.com/18598077/The-backseat-lovers-kilby-girl/Feels-like-a-night-to-carry-a-tune-ive-been-carrying-yours-since-you-wrecked-my-room\"}},\"6\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/28803708/The-backseat-lovers-kilby-girl/And-ive-got-nothin-to-do-and-neither-do-you\",\"url\":\"https://genius.com/28803708/The-backseat-lovers-kilby-girl/And-ive-got-nothin-to-do-and-neither-do-you\"}},\"7\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/20947129/The-backseat-lovers-kilby-girl/So-well-chase-jack-with-love\",\"url\":\"https://genius.com/20947129/The-backseat-lovers-kilby-girl/So-well-chase-jack-with-love\"}},\"8\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/28803726/The-backseat-lovers-kilby-girl/I-overheard-that-she-was-nineteen-shes-got-a-fake-id-and-a-nose-ring-those-kind-of-girls-tend-to-know-things-better-than-i-do\",\"url\":\"https://genius.com/28803726/The-backseat-lovers-kilby-girl/I-overheard-that-she-was-nineteen-shes-got-a-fake-id-and-a-nose-ring-those-kind-of-girls-tend-to-know-things-better-than-i-do\"}},\"9\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/16766126/The-backseat-lovers-kilby-girl/To-figure-out-what-shes-hiding-shes-playing-it-cool-but-shes-lying-better-than-i-do\",\"url\":\"https://genius.com/16766126/The-backseat-lovers-kilby-girl/To-figure-out-what-shes-hiding-shes-playing-it-cool-but-shes-lying-better-than-i-do\"}}}}",
+    "generatedImageLog": [],
+    "promptLog": [],
+    "images": []
+  },
+  {
+    "id": "(Demo) Thrown - Bitter Friend",
+    "projectDetail": {
+      "name": "(Demo) Thrown - Bitter Friend",
+      "createdDate": "2024-10-22T14:57:24.088Z",
+      "audioFileName": " https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview221/v4/c9/7f/84/c97f84b4-9230-8501-fd8c-ad114e42e634/mzaf_17329938829876669766.plus.aac.p.m4a",
+      "audioFileUrl": " https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview221/v4/c9/7f/84/c97f84b4-9230-8501-fd8c-ad114e42e634/mzaf_17329938829876669766.plus.aac.p.m4a",
+      "isLocalUrl": false,
+      "editingMode": "static",
+      "albumArtSrc": "https://cdns-images.dzcdn.net/images/cover/47991582fbc76289ca13c9c4f9edacb7/0x1900-000000-80-0-0.jpg",
+      "resolution": "16/9"
+    },
+    "lyricTexts": [
+      {
+        "id": 1729609309327.3,
+        "start": 8.273240816326531,
+        "end": 10.85594775510204,
+        "text": "On my own, all alone, don't need anyone",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729609359473.9,
+        "start": 10.932125895691591,
+        "end": 13.814587936507916,
+        "text": "Since every friend finds a new way to disappoint",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729609414388.8,
+        "start": 13.860675918367347,
+        "end": 16.611245714285715,
+        "text": "Not sure if I've become bitter to the core",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729609528773.9,
+        "start": 16.64873070294785,
+        "end": 19.47124172335602,
+        "text": "Or gotten cold from the snow, fuck if I know",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729634118675.2,
+        "start": 19.53189442176914,
+        "end": 21.539071564626283,
+        "text": "You're dead to me, you get me?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729634155637.2,
+        "start": 21.606347755102043,
+        "end": 23.721436734693885,
+        "text": "And you can think that I'm a bitter friend",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729634217373.7,
+        "start": 23.76973061224456,
+        "end": 25.04550530612211,
+        "text": "Thought I had better friends",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729634297407.1,
+        "start": 25.12406639455747,
+        "end": 29.888990476190124,
+        "text": "You're all dead to me, you're all dead to me\nYou're all dead, you get me?",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": false
+      },
+      {
+        "id": 1729631669608,
+        "start": -0.07194122448979591,
+        "end": 30.02828408163265,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 79.4
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 0.5,
+            "beatSyncIntensity": 2.43
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.56,
+              "color": {
+                "r": 255,
+                "g": 255,
+                "b": 255,
+                "a": 1
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.257,
+              "color": {
+                "r": 4,
+                "g": 84,
+                "b": 132,
+                "a": 1
+              },
+              "beatSyncIntensity": 1.151
+            },
+            {
+              "stop": 0.555,
+              "color": {
+                "r": 5,
+                "g": 180,
+                "b": 203,
+                "a": 1
+              },
+              "beatSyncIntensity": 0.653
+            },
+            {
+              "stop": 0.47,
+              "color": {
+                "r": 0,
+                "g": 0,
+                "b": 0,
+                "a": 1
+              },
+              "beatSyncIntensity": 1
+            }
+          ]
+        }
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"r0qt\",\"text\":\"[Pre-Chorus]\\nOn my own, all alone, don't need anyone\\nSince every friend finds a new way to disappoint\\nNot sure if I've become bitter to the core\\nOr gotten cold from the snow, fuck if I know\\n\\n[Chorus]\\nYou're dead to me, you get me?\\nAnd you can think that I'm a bitter friend\\nThought I had better friends\\nYou're dead to me, you get me?\\nSo let me tie up any loose ends by telling you again\\n\\n[Verse 2]\\nYou're all dead to me, m-motherfuckers\\nI don't owе any apologies\\nNah, I'm just being real, I don't carе how you feel\\nKeep saying that you're sorry, I'm not listening\\nAll you're doing's just talking, and talking, and talking\\nSo fuck it, what does it matter if I am the subject? (Yeah)\\nYou're just talking, talking, talking\\nAnd then you're acting like the drama isn't what you wanted\\nHey\\n\\n[Pre-Chorus]\\nOn my own, all alone, don't need anyone\\nSince every friend finds a new way to disappoint\\nNot sure if I've become bitter to the core\\nOr gotten cold from the snow, fuck if I know\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"dipbe\",\"text\":\"See rock shows near Somerville\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":30,\"key\":0}],\"data\":{}},{\"key\":\"5ibud\",\"text\":\"Get tickets as low as $66\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":25,\"key\":0}],\"data\":{}},{\"key\":\"56r89\",\"text\":\"You might also like\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"5ku5g\",\"text\":\"​ignored\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":8,\"key\":1}],\"data\":{}},{\"key\":\"2ttom\",\"text\":\"​​thrown\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":8,\"key\":1}],\"data\":{}},{\"key\":\"7o20c\",\"text\":\"​look at me\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":11,\"key\":2}],\"data\":{}},{\"key\":\"7ags6\",\"text\":\"​​thrown\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":8,\"key\":2}],\"data\":{}},{\"key\":\"di3u\",\"text\":\"​bloodsucker\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":12,\"key\":3}],\"data\":{}},{\"key\":\"b8go\",\"text\":\"​​thrown\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[{\"offset\":0,\"length\":8,\"key\":3}],\"data\":{}},{\"key\":\"7ufem\",\"text\":\"[Chorus]\\nYou're dead to me, you get me?\\nAnd you can think that I'm a bitter friend\\nThought I had better friends\\nYou're all dead to me, you're all dead to me\\nYou're all dead, you get me?\\n\\n[Outro]\\nAll you're doing's just talking, and talking, and talking\\nSo fuck it, what does it matter if I am the subject?\\nYou're just talking, talking, talking\\nAnd then you're acting like the drama isn't what you wanted\\nSo fuck it (So fuck it)\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{\"0\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://stubhub.prf.hn/click/camref:1100lqTK8/pubref:category/destination:https%3A%2F%2Fwww.stubhub.com%2F_C-259827\",\"target\":\"_blank\",\"url\":\"https://stubhub.prf.hn/click/camref:1100lqTK8/pubref:category/destination:https%3A%2F%2Fwww.stubhub.com%2F_C-259827\"}},\"1\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/Thrown-ignored-lyrics\",\"url\":\"https://genius.com/Thrown-ignored-lyrics\"}},\"2\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/Thrown-look-at-me-lyrics\",\"url\":\"https://genius.com/Thrown-look-at-me-lyrics\"}},\"3\":{\"type\":\"LINK\",\"mutability\":\"MUTABLE\",\"data\":{\"href\":\"https://genius.com/Thrown-bloodsucker-lyrics\",\"url\":\"https://genius.com/Thrown-bloodsucker-lyrics\"}}}}",
+    "generatedImageLog": [],
+    "promptLog": [],
+    "images": []
+  },
+  {
+    "id": "(Demo) Lunar Vacation - Swimming",
+    "projectDetail": {
+      "name": "(Demo) Lunar Vacation - Swimming",
+      "createdDate": "2024-03-03T21:11:49.884Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/d0/00/c8/d000c8c8-57c9-f09b-b2df-b7aaedf24c54/mzaf_7829899316074841132.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/d0/00/c8/d000c8c8-57c9-f09b-b2df-b7aaedf24c54/mzaf_7829899316074841132.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "resolution": "16/9",
+      "albumArtSrc": "https://f4.bcbits.com/img/a2587411320_10.jpg"
+    },
+    "lyricTexts": [
+      {
+        "id": 1709504211675.9,
+        "start": 5.796976501099697,
+        "end": 10.85512691461788,
+        "text": "she's starting to cry",
+        "textY": 0.546569676542612,
+        "textX": 0.3077225628542585,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.3916913946587532,
+        "height": 20.894,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716903499516.5,
+        "start": -0.43045071912588356,
+        "end": 30.50913441408951,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 6,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 105
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 5,
+            "beatSyncIntensity": 1.74
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.069,
+              "color": {
+                "r": 255,
+                "g": 179,
+                "b": 186
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.25,
+              "color": {
+                "r": 255,
+                "g": 223,
+                "b": 186
+              },
+              "beatSyncIntensity": 1.099
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716904185583.8,
+        "start": 12.800514788811153,
+        "end": 19.4638634880928,
+        "text": "she saw the way",
+        "textY": 0.501796001858439,
+        "textX": 0.35527414151618925,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.2804154302670622,
+        "height": 20.893999999999988,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716904334449.9,
+        "start": 5.804978715087038,
+        "end": 10.864628748009796,
+        "text": "She can't sleep at night ",
+        "textY": 0.38572592342749307,
+        "textX": 0.27804897234980724,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.4480712166172101,
+        "height": 20.894000000000016,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716904497412.8,
+        "start": 5.81226269423325,
+        "end": 10.863775860778102,
+        "text": "and ",
+        "textY": 0.46746619140402873,
+        "textX": 0.47092731062873916,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.0565936261185552,
+        "height": 20.89399999999999,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716905356268.4,
+        "start": 12.805951274376419,
+        "end": 19.45817063939566,
+        "text": "And in the middle of the night ",
+        "textY": 0.44496317854964235,
+        "textX": 0.21874609165379064,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.5608308605341245,
+        "height": 20.894000000000023,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716905985036.3,
+        "start": 22.217162991492227,
+        "end": 28.963146274371127,
+        "text": "she felt okay",
+        "textY": 0.500490518829718,
+        "textX": 0.37583892007583897,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.2436926114105448,
+        "height": 42.215111111111106,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716905985037.3,
+        "start": 22.221610788703973,
+        "end": 28.96191654716587,
+        "text": "And in the middle of the night",
+        "textY": 0.4423522124922011,
+        "textX": 0.21727717889953005,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.5608308605341245,
+        "height": 20.894000000000023,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716907017934.7,
+        "start": 34.01768967857755,
+        "end": 89.92498604988263,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 6,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 105
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 5,
+            "beatSyncIntensity": 1.74
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.069,
+              "color": {
+                "r": 255,
+                "g": 179,
+                "b": 186
+              },
+              "beatSyncIntensity": 0
+            },
+            {
+              "stop": 0.25,
+              "color": {
+                "r": 255,
+                "g": 223,
+                "b": 186
+              },
+              "beatSyncIntensity": 1.099
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716907108053.5,
+        "start": 30.500285550138333,
+        "end": 34.02023183294456,
+        "text": "",
+        "textY": 0.5,
+        "textX": 0.5,
+        "textBoxTimelineLevel": 5,
+        "isImage": false,
+        "imageUrl": "",
+        "fontName": "Inter Variable",
+        "fontWeight": 400,
+        "isVisualizer": true,
+        "visualizerSettings": {
+          "fillRadialGradientStartPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientEndPoint": {
+            "x": 50,
+            "y": 50
+          },
+          "fillRadialGradientStartRadius": {
+            "value": 105
+          },
+          "fillRadialGradientEndRadius": {
+            "value": 5,
+            "beatSyncIntensity": 1.94
+          },
+          "fillRadialGradientColorStops": [
+            {
+              "stop": 0.069,
+              "color": {
+                "r": 255,
+                "g": 179,
+                "b": 186
+              },
+              "beatSyncIntensity": 1.122
+            },
+            {
+              "stop": 0.25,
+              "color": {
+                "r": 255,
+                "g": 223,
+                "b": 186
+              },
+              "beatSyncIntensity": 1.099
+            }
+          ]
+        }
+      },
+      {
+        "id": 1716907502686.3,
+        "start": 52.52041477709881,
+        "end": 57.578565190616985,
+        "text": "just not enough?",
+        "textY": 0.5387367783702879,
+        "textX": 0.3503210327278188,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.29768097838606855,
+        "height": 42.2151111111111,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716907502687.3,
+        "start": 52.5197071186303,
+        "end": 57.58806702400891,
+        "text": "Am I too much",
+        "textY": 0.39486430462853733,
+        "textX": 0.377200583262404,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.24242343102071282,
+        "height": 42.215111111111085,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716907502688.3,
+        "start": 52.52118451613928,
+        "end": 57.587214136777206,
+        "text": "or",
+        "textY": 0.4674661914040286,
+        "textX": 0.4797407871543033,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.03896667306742694,
+        "height": 42.215111111111106,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716907806112.8,
+        "start": 61.475760471655335,
+        "end": 66.53391088517351,
+        "text": "I'm sure I'll catch on",
+        "textY": 0.5387367783702879,
+        "textX": 0.29670571719730343,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.4107872604641424,
+        "height": 42.21511111111101,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716907806114.8,
+        "start": 61.47505281318683,
+        "end": 66.54341271856542,
+        "text": "Keep telling me both,",
+        "textY": 0.39878075371469923,
+        "textX": 0.30742722743502104,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.39078361920104304,
+        "height": 42.215111111111,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      },
+      {
+        "id": 1716907806115.8,
+        "start": 61.476530210695806,
+        "end": 66.54255983133372,
+        "text": "and",
+        "textY": 0.4674661914040286,
+        "textX": 0.4701928542516088,
+        "textBoxTimelineLevel": 3,
+        "isImage": false,
+        "imageUrl": "",
+        "width": 0.05659362611855544,
+        "height": 42.2151111111111,
+        "fontWeight": "300",
+        "fontName": "Courier New",
+        "shadowBlur": 11.2,
+        "fontSize": 31,
+        "shadowColor": {
+          "r": 230,
+          "g": 92,
+          "b": 92,
+          "a": 1
+        }
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"d9n81\",\"text\":\"She had a party and nobody came\\nLooking around and they're all just the same\\nThe least you could do was just tell me a lie\\nShe can't sleep at night and she's starting to cry\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"87s6c\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"egkd6\",\"text\":\"And in the middle of the night she saw the way\\nAnd in the middle of the night she felt okay\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"b3dji\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6qb9s\",\"text\":\"Am I too much or just not enough?\\nKeep telling me both, and I'm sure I'll catch on\\nIf this isn't what you wanted at all\\nThe reflection from your eyes can fall\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"a5ndt\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"do70u\",\"text\":\"And in the middle of the night she saw the way\\nAnd in the middle of the night she felt okay\\nAnd in the middle of the night she saw the way\\nAnd in the middle of the night she felt okay\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"2t4p5\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"1lhnh\",\"text\":\"And in the middle of the night she saw the way\\nAnd in the middle of the night she felt okay\\nAnd in the middle of the night she saw the way\\nAnd in the middle of the night she felt okay\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": []
+  },
+  {
+    "id": "(Demo) Mr loverman",
+    "projectDetail": {
+      "name": "(Demo) Mr loverman",
+      "createdDate": "2024-03-03T21:26:53.681Z",
+      "audioFileName": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview112/v4/1a/12/2c/1a122c1f-cafb-f515-6341-eaf9487400ac/mzaf_14883734460618248333.plus.aac.ep.m4a",
+      "audioFileUrl": "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview112/v4/1a/12/2c/1a122c1f-cafb-f515-6341-eaf9487400ac/mzaf_14883734460618248333.plus.aac.ep.m4a",
+      "isLocalUrl": false,
+      "resolution": "16/9",
+      "albumArtSrc": "https://t2.genius.com/unsafe/495x495/https%3A%2F%2Fimages.genius.com%2Fc17eacd4676137d5780d7ec97b48d6d1.816x816x1.jpg"
+    },
+    "lyricTexts": [
+      {
+        "id": 1709501819652.2,
+        "start": 1.2691083900227114,
+        "end": 3.8338805260771323,
+        "text": "I'm Mr. Loverman",
+        "textY": 0.4960835509138381,
+        "textX": 0.4484536082474227,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "500",
+        "fontName": "Trebuchet MS"
+      },
+      {
+        "id": 1709501493758.1,
+        "start": 6.4224020317460395,
+        "end": 9.940426158730167,
+        "text": "And I miss my lover, man",
+        "textY": 0.5,
+        "textX": 0.46170839469808544,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": ""
+      },
+      {
+        "id": 1709501544204.2,
+        "start": 12.15845935600907,
+        "end": 15.334751637188209,
+        "text": "I'm Mr. Loverman",
+        "textY": 0.4960835509138381,
+        "textX": 0.4484536082474227,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "500",
+        "fontName": "Trebuchet MS"
+      },
+      {
+        "id": 1709501571990.1,
+        "start": 16.295213278911564,
+        "end": 20.118997478458052,
+        "text": "Oh, and I miss my lover",
+        "textY": 0.4960835509138381,
+        "textX": 0.4484536082474227,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "500",
+        "fontName": "Trebuchet MS"
+      },
+      {
+        "id": 1709501611253.8,
+        "start": 23.27373728798186,
+        "end": 27.097521487528347,
+        "text": "The ways in which you talk to me",
+        "textY": 0.49216710182767626,
+        "textX": 0.4005891016200295,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "500",
+        "fontName": "Trebuchet MS"
+      },
+      {
+        "id": 1709501671758.3,
+        "start": 26.331338013605446,
+        "end": 27.673069859410433,
+        "text": "Suguru",
+        "textY": 0.3825065274151436,
+        "textX": 0.18851251840942562,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "200",
+        "fontName": "Trebuchet MS",
+        "fontSize": 13
+      },
+      {
+        "id": 1709501895007.9,
+        "start": 27.89611014965987,
+        "end": 32.27745683446713,
+        "text": "Have me wishin' I were gone",
+        "textY": 0.49216710182767626,
+        "textX": 0.4005891016200295,
+        "textBoxTimelineLevel": 1,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "500",
+        "fontName": "Trebuchet MS"
+      },
+      {
+        "id": 1709501895008.9,
+        "start": 31.76307577324264,
+        "end": 33.10480761904762,
+        "text": "Satoru",
+        "textY": 0.3825065274151436,
+        "textX": 0.7665684830633285,
+        "textBoxTimelineLevel": 2,
+        "isImage": false,
+        "imageUrl": "",
+        "fontWeight": "200",
+        "fontName": "Trebuchet MS",
+        "fontSize": 13
+      }
+    ],
+    "lyricReference": "{\"blocks\":[{\"key\":\"b5k1t\",\"text\":\"'m headed straight for the floor\\nThe alcohol served its tour\\nAnd it's headed straight for my skin\\nLeaving me daft and dim\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"ek3td\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"4qcg7\",\"text\":\"I've got this shake in my legs\\nShaking the thoughts from my head\\nBut who put these waves in the door?\\nI crack and out I pour\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"di8hb\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"59ruv\",\"text\":\"I'm Mr. Loverman\\nAnd I miss my lover, man\\nI'm Mr. Loverman\\nOh, and I miss my lover\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"flvr9\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"drncd\",\"text\":\"The ways in which you talk to me\\nHave me wishin' I were gone\\nThe ways that you say my name\\nHave me runnin' on and on\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"7d5db\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"13hcl\",\"text\":\"Oh, I'm cramping up\\nI'm cramping up\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"6bkbj\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"ci9vq\",\"text\":\"But you're cracking up\\nYou're cracking up\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"dpjrh\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"ftrfd\",\"text\":\"I'm Mr. Loverman\\nAnd I miss my loverman\\nI'm Mr. Loverman\\nOh, and I miss my lover\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"13rm8\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"2d1lk\",\"text\":\"I've shattered now, I'm spilling out\\nUpon this linoleum ground (Mr. Loverman)\\nI'm reeling in my brain again\\nBefore it can get back to you (Mr. Loverman)\\nOh what am I supposed to do without you?\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"dmasr\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"b2fv4\",\"text\":\"I'm Mr. Loverman\\nAnd I miss my lover, man (I miss my lover)\\nI'm Mr. Loverman (oh-oh)\\nOh, and I miss my lover (Mr. Loverman)\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"dmm8a\",\"text\":\"\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}},{\"key\":\"fccp\",\"text\":\"I'm Mr. Loverman (oh-oh)\\nAnd I miss my loverman\\nI'm Mr. Loverman\\nAnd I miss my lover\",\"type\":\"unstyled\",\"depth\":0,\"inlineStyleRanges\":[],\"entityRanges\":[],\"data\":{}}],\"entityMap\":{}}",
+    "generatedImageLog": [],
+    "promptLog": []
+  }
+]

--- a/src/Project/PublishedLyrictorPage.tsx
+++ b/src/Project/PublishedLyrictorPage.tsx
@@ -211,10 +211,18 @@ export default function PublishedLyrictorPage() {
       setNotFound(false);
 
       try {
-        // Try demo projects first
-        const response = await fetch(DEMO_PROJECTS_URL);
-        const projects: Project[] = await response.json();
-        let project = projects.find((p) => p.id === publishedId);
+        let project: Project | undefined;
+
+        try {
+          // Try demo projects first
+          const response = await fetch(DEMO_PROJECTS_URL);
+          if (response.ok) {
+            const projects: Project[] = await response.json();
+            project = projects.find((p) => p.id === publishedId);
+          }
+        } catch (error) {
+          console.warn("Failed to load demo project:", error);
+        }
 
         // Fall back to Firestore published collection
         if (!project) {

--- a/src/Project/PublishedLyrictorPage.tsx
+++ b/src/Project/PublishedLyrictorPage.tsx
@@ -25,9 +25,8 @@ import ImmersiveLyricPreview from "../components/ImmersiveLyricPreview";
 import { loadProjectIntoEditor } from "./loadProjectIntoEditor";
 import { useImagePreload } from "./useImagePreload";
 import { useDocumentTitle } from "../useDocumentTitle";
+import { getDemoProject } from "./demoProjects";
 
-const DEMO_PROJECTS_URL =
-  "https://firebasestorage.googleapis.com/v0/b/angelic-phoenix-314404.appspot.com/o/demo_projects.json?alt=media";
 const LOCAL_PREVIEW_ROUTE_ID = "local";
 const PROJECT_INFO_LAYOUT_GAP = 40;
 const PROJECT_INFO_LAYOUT_PADDING = 48;
@@ -211,18 +210,7 @@ export default function PublishedLyrictorPage() {
       setNotFound(false);
 
       try {
-        let project: Project | undefined;
-
-        try {
-          // Try demo projects first
-          const response = await fetch(DEMO_PROJECTS_URL);
-          if (response.ok) {
-            const projects: Project[] = await response.json();
-            project = projects.find((p) => p.id === publishedId);
-          }
-        } catch (error) {
-          console.warn("Failed to load demo project:", error);
-        }
+        let project = getDemoProject(publishedId);
 
         // Fall back to Firestore published collection
         if (!project) {

--- a/src/Project/demoProjects.ts
+++ b/src/Project/demoProjects.ts
@@ -1,0 +1,10 @@
+import demoProjects from "../../demo_projects.json";
+import { Project } from "./types";
+
+export function getDemoProjects(): Project[] {
+  return demoProjects as unknown as Project[];
+}
+
+export function getDemoProject(projectId: string): Project | undefined {
+  return getDemoProjects().find((project) => project.id === projectId);
+}

--- a/src/Project/store.ts
+++ b/src/Project/store.ts
@@ -21,6 +21,7 @@ import {
   deleteProjectFromFirestore,
 } from "./firestoreProjectService";
 import { useAIImageGeneratorStore } from "../Editor/Image/AI/store";
+import { getDemoProjects } from "./demoProjects";
 
 export interface EditingProjectAccess {
   source?: Project["source"];
@@ -625,40 +626,18 @@ export async function isProjectExist(projectDetail: ProjectDetail): Promise<bool
   return isProjectInLocalStorage(projectDetail);
 }
 
-let cachedSampleProjects: Project[] = [];
-
 export const loadProjects = async (demoOnly?: boolean): Promise<Project[]> => {
   const { user, storagePreference } = useAuthStore.getState();
-  const sampleUrl =
-    "https://firebasestorage.googleapis.com/v0/b/angelic-phoenix-314404.appspot.com/o/demo_projects.json?alt=media";
-
-  const fetchSampleProjects = async (): Promise<Project[]> => {
-    if (cachedSampleProjects.length > 0) {
-      return cachedSampleProjects;
-    }
-    try {
-      const response = await fetch(sampleUrl);
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch sample projects: ${response.statusText}`
-        );
-      }
-      cachedSampleProjects = await response.json();
-    } catch (error) {
-      console.warn("Failed to fetch sample projects:", error);
-      cachedSampleProjects = [];
-    }
-    return cachedSampleProjects;
-  };
+  const demoProjects = getDemoProjects();
 
   if (demoOnly) {
-    return (await fetchSampleProjects()).map((p) => ({
+    return demoProjects.map((p) => ({
       ...normalizeProject(p),
       source: "demo" as const,
     }));
   }
 
-  const sampleProjects = (await fetchSampleProjects()).map((p) => ({
+  const sampleProjects = demoProjects.map((p) => ({
     ...normalizeProject(p),
     source: "demo" as const,
   }));

--- a/src/Project/store.ts
+++ b/src/Project/store.ts
@@ -636,13 +636,18 @@ export const loadProjects = async (demoOnly?: boolean): Promise<Project[]> => {
     if (cachedSampleProjects.length > 0) {
       return cachedSampleProjects;
     }
-    const response = await fetch(sampleUrl);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch sample projects: ${response.statusText}`
-      );
+    try {
+      const response = await fetch(sampleUrl);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch sample projects: ${response.statusText}`
+        );
+      }
+      cachedSampleProjects = await response.json();
+    } catch (error) {
+      console.warn("Failed to fetch sample projects:", error);
+      cachedSampleProjects = [];
     }
-    cachedSampleProjects = await response.json();
     return cachedSampleProjects;
   };
 


### PR DESCRIPTION
This pull request refactors how demo projects are loaded across the codebase, switching from fetching demo projects from a remote Firebase URL to reading them directly from a local `demo_projects.json` file. This change improves performance, reliability, and simplifies the handling of demo project data. Below are the most important changes:

**Backend/API changes:**
* Both `api/lyrictor-meta.js` and `api/sitemap.js` now read demo projects from a local file (`demo_projects.json`) using Node's `fs/promises` and cache the result, instead of fetching from a remote URL. [[1]](diffhunk://#diff-60da969a239c896e4fa6ef0f596f0f2d63697094addda2aa441658fb6ea01139R1-R8) [[2]](diffhunk://#diff-60da969a239c896e4fa6ef0f596f0f2d63697094addda2aa441658fb6ea01139L96-R105) [[3]](diffhunk://#diff-b1f88ed544a9a04791f333e3e550d6245a9881ab48ab1a4ae924699f1928b30bL1-R5) [[4]](diffhunk://#diff-b1f88ed544a9a04791f333e3e550d6245a9881ab48ab1a4ae924699f1928b30bL96-R105)

**Frontend changes:**
* A new module, `src/Project/demoProjects.ts`, is added to provide helper functions (`getDemoProjects`, `getDemoProject`) for accessing demo projects from the local JSON file.
* Project loading logic in `src/Project/PublishedLyrictorPage.tsx` and `src/Project/store.ts` is updated to use the new local demo project helpers instead of fetching from the remote Firebase URL. [[1]](diffhunk://#diff-4d9a5b39420126ea645db5ba6bf9a063cfb7486b5ec7ae51a164f226ff64541dR28-L30) [[2]](diffhunk://#diff-4d9a5b39420126ea645db5ba6bf9a063cfb7486b5ec7ae51a164f226ff64541dL214-R213) [[3]](diffhunk://#diff-20a82c42de9700d3e5fa006c15101d6532346aef9b808887bea2b7b90ac99705R24) [[4]](diffhunk://#diff-20a82c42de9700d3e5fa006c15101d6532346aef9b808887bea2b7b90ac99705L628-R640)

These changes remove all remote fetching of demo projects, centralize demo project access, and improve code maintainability.